### PR TITLE
Add stores for accounts, device groups and devices

### DIFF
--- a/src/helpers/fetch.wrapper.js
+++ b/src/helpers/fetch.wrapper.js
@@ -27,6 +27,7 @@ export const fetchWrapper = {
   get: request('GET'),
   post: request('POST'),
   put: request('PUT'),
+  patch: request('PATCH'),
   delete: request('DELETE'),
   postFile: requestFile('POST'),
   getFile: requestBlob('GET'),

--- a/src/stores/accounts.store.js
+++ b/src/stores/accounts.store.js
@@ -1,0 +1,128 @@
+// Copyright (c) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// This file is a part of Media Pi frontend application
+
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { fetchWrapper } from '@/helpers/fetch.wrapper.js'
+import { apiUrl } from '@/helpers/config.js'
+
+const baseUrl = `${apiUrl}/accounts`
+
+export const useAccountsStore = defineStore('accounts', () => {
+  const accounts = ref([])
+  const account = ref(null)
+  const loading = ref(false)
+  const error = ref(null)
+
+  const getAccountById = (id) => {
+    if (!accounts || !Array.isArray(accounts.value)) {
+      return null
+    }
+    return accounts.value.find(account => account && account.id === id)
+  }
+
+  async function add(accountParam) {
+    loading.value = true
+    error.value = null
+    try {
+      await fetchWrapper.post(baseUrl, accountParam)
+      getAll()
+    } catch (err) {
+      error.value = err
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function getAll() {
+    loading.value = true
+    error.value = null
+    try {
+      const result = await fetchWrapper.get(baseUrl)
+      accounts.value = result || []
+    } catch (err) {
+      error.value = err
+      accounts.value = []
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function getById(id) {
+    loading.value = true
+    error.value = null
+    try {
+      const result = await fetchWrapper.get(`${baseUrl}/${id}`)
+      account.value = result
+    } catch (err) {
+      error.value = err
+      account.value = null
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function update(id, params) {
+    loading.value = true
+    error.value = null
+    try {
+      await fetchWrapper.put(`${baseUrl}/${id}`, params)
+      getAll()
+    } catch (err) {
+      error.value = err
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function deleteAccount(id) {
+    loading.value = true
+    error.value = null
+    try {
+      await fetchWrapper.delete(`${baseUrl}/${id}`, {})
+      getAll()
+    } catch (err) {
+      error.value = err
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return {
+    accounts,
+    account,
+    loading,
+    error,
+    getAccountById,
+    add,
+    getAll,
+    getById,
+    update,
+    delete: deleteAccount
+  }
+})
+

--- a/src/stores/device.groups.store.js
+++ b/src/stores/device.groups.store.js
@@ -1,0 +1,128 @@
+// Copyright (c) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// This file is a part of Media Pi frontend application
+
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { fetchWrapper } from '@/helpers/fetch.wrapper.js'
+import { apiUrl } from '@/helpers/config.js'
+
+const baseUrl = `${apiUrl}/devicegroups`
+
+export const useDeviceGroupsStore = defineStore('devicegroups', () => {
+  const groups = ref([])
+  const group = ref(null)
+  const loading = ref(false)
+  const error = ref(null)
+
+  const getGroupById = (id) => {
+    if (!groups || !Array.isArray(groups.value)) {
+      return null
+    }
+    return groups.value.find(g => g && g.id === id)
+  }
+
+  async function add(groupParam) {
+    loading.value = true
+    error.value = null
+    try {
+      await fetchWrapper.post(baseUrl, groupParam)
+      getAll()
+    } catch (err) {
+      error.value = err
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function getAll() {
+    loading.value = true
+    error.value = null
+    try {
+      const result = await fetchWrapper.get(baseUrl)
+      groups.value = result || []
+    } catch (err) {
+      error.value = err
+      groups.value = []
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function getById(id) {
+    loading.value = true
+    error.value = null
+    try {
+      const result = await fetchWrapper.get(`${baseUrl}/${id}`)
+      group.value = result
+    } catch (err) {
+      error.value = err
+      group.value = null
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function update(id, params) {
+    loading.value = true
+    error.value = null
+    try {
+      await fetchWrapper.put(`${baseUrl}/${id}`, params)
+      getAll()
+    } catch (err) {
+      error.value = err
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function deleteGroup(id) {
+    loading.value = true
+    error.value = null
+    try {
+      await fetchWrapper.delete(`${baseUrl}/${id}`, {})
+      getAll()
+    } catch (err) {
+      error.value = err
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return {
+    groups,
+    group,
+    loading,
+    error,
+    getGroupById,
+    add,
+    getAll,
+    getById,
+    update,
+    delete: deleteGroup
+  }
+})
+

--- a/src/stores/devices.store.js
+++ b/src/stores/devices.store.js
@@ -1,0 +1,176 @@
+// Copyright (c) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// This file is a part of Media Pi frontend application
+
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { fetchWrapper } from '@/helpers/fetch.wrapper.js'
+import { apiUrl } from '@/helpers/config.js'
+
+const baseUrl = `${apiUrl}/devices`
+
+export const useDevicesStore = defineStore('devices', () => {
+  const devices = ref([])
+  const device = ref(null)
+  const loading = ref(false)
+  const error = ref(null)
+
+  const getDeviceById = (id) => {
+    if (!devices || !Array.isArray(devices.value)) {
+      return null
+    }
+    return devices.value.find(d => d && d.id === id)
+  }
+
+  async function register() {
+    loading.value = true
+    error.value = null
+    try {
+      const result = await fetchWrapper.post(`${baseUrl}/register`, {})
+      getAll()
+      return result
+    } catch (err) {
+      error.value = err
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function getAll() {
+    loading.value = true
+    error.value = null
+    try {
+      const result = await fetchWrapper.get(baseUrl)
+      devices.value = result || []
+    } catch (err) {
+      error.value = err
+      devices.value = []
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function getAllByAccount(accountId) {
+    loading.value = true
+    error.value = null
+    try {
+      const url = accountId == null ? `${baseUrl}/by-account` : `${baseUrl}/by-account/${accountId}`
+      const result = await fetchWrapper.get(url)
+      devices.value = result || []
+    } catch (err) {
+      error.value = err
+      devices.value = []
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function getById(id) {
+    loading.value = true
+    error.value = null
+    try {
+      const result = await fetchWrapper.get(`${baseUrl}/${id}`)
+      device.value = result
+    } catch (err) {
+      error.value = err
+      device.value = null
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function update(id, params) {
+    loading.value = true
+    error.value = null
+    try {
+      await fetchWrapper.put(`${baseUrl}/${id}`, params)
+      getAll()
+    } catch (err) {
+      error.value = err
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function deleteDevice(id) {
+    loading.value = true
+    error.value = null
+    try {
+      await fetchWrapper.delete(`${baseUrl}/${id}`, {})
+      getAll()
+    } catch (err) {
+      error.value = err
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function assignGroup(id, params) {
+    loading.value = true
+    error.value = null
+    try {
+      await fetchWrapper.patch(`${baseUrl}/assign-group/${id}`, params)
+      getAll()
+    } catch (err) {
+      error.value = err
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function initialAssignAccount(id, params) {
+    loading.value = true
+    error.value = null
+    try {
+      await fetchWrapper.patch(`${baseUrl}/initial-assign-account/${id}`, params)
+      getAll()
+    } catch (err) {
+      error.value = err
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return {
+    devices,
+    device,
+    loading,
+    error,
+    getDeviceById,
+    register,
+    getAll,
+    getAllByAccount,
+    getById,
+    update,
+    delete: deleteDevice,
+    assignGroup,
+    initialAssignAccount
+  }
+})
+

--- a/src/stores/devices.store.js
+++ b/src/stores/devices.store.js
@@ -74,7 +74,7 @@ export const useDevicesStore = defineStore('devices', () => {
     loading.value = true
     error.value = null
     try {
-      const url = accountId == null ? `${baseUrl}/by-account` : `${baseUrl}/by-account/${accountId}`
+      const url = accountId === null ? `${baseUrl}/by-account` : `${baseUrl}/by-account/${accountId}`
       const result = await fetchWrapper.get(url)
       devices.value = result || []
     } catch (err) {

--- a/tests/accounts.store.spec.js
+++ b/tests/accounts.store.spec.js
@@ -1,0 +1,141 @@
+// Copyright (c) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// This file is a part of Media Pi frontend application
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useAccountsStore } from '@/stores/accounts.store.js'
+import { fetchWrapper } from '@/helpers/fetch.wrapper.js'
+
+vi.mock('@/helpers/fetch.wrapper.js', () => {
+  return {
+    fetchWrapper: {
+      get: vi.fn(),
+      post: vi.fn(),
+      put: vi.fn(),
+      delete: vi.fn(),
+      patch: vi.fn()
+    }
+  }
+})
+
+const mockAccounts = [
+  { id: 1, name: 'Account 1' },
+  { id: 2, name: 'Account 2' }
+]
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  vi.clearAllMocks()
+})
+
+describe('accounts.store', () => {
+  it('getAccountById returns correct account', () => {
+    const store = useAccountsStore()
+    store.$patch({ accounts: mockAccounts })
+
+    expect(store.getAccountById(1)).toEqual(mockAccounts[0])
+    expect(store.getAccountById(999)).toBeUndefined()
+  })
+
+  it('add calls fetchWrapper.post', async () => {
+    const store = useAccountsStore()
+    fetchWrapper.post.mockResolvedValueOnce({})
+    await store.add({ name: 'Account 3' })
+    expect(fetchWrapper.post).toHaveBeenCalled()
+  })
+
+  it('getAll sets accounts from fetch', async () => {
+    const store = useAccountsStore()
+    fetchWrapper.get.mockResolvedValueOnce(mockAccounts)
+    await store.getAll()
+    expect(store.accounts).toEqual(mockAccounts)
+  })
+
+  it('getById sets account from fetch', async () => {
+    const store = useAccountsStore()
+    fetchWrapper.get.mockResolvedValueOnce(mockAccounts[0])
+    await store.getById(1)
+    expect(store.account).toEqual(mockAccounts[0])
+  })
+
+  it('update calls fetchWrapper.put', async () => {
+    const store = useAccountsStore()
+    fetchWrapper.put.mockResolvedValueOnce({})
+    await store.update(1, { name: 'Updated' })
+    expect(fetchWrapper.put).toHaveBeenCalled()
+  })
+
+  it('delete calls fetchWrapper.delete', async () => {
+    const store = useAccountsStore()
+    fetchWrapper.delete.mockResolvedValueOnce({})
+    await store.delete(1)
+    expect(fetchWrapper.delete).toHaveBeenCalled()
+  })
+
+  it('add throws error and sets error state when fetch fails', async () => {
+    const store = useAccountsStore()
+    const mockError = new Error('Add failed')
+    fetchWrapper.post.mockRejectedValueOnce(mockError)
+    await expect(store.add({ name: 'Acc' })).rejects.toThrow('Add failed')
+    expect(store.error).toBe(mockError)
+    expect(store.loading).toBe(false)
+  })
+
+  it('getAll throws error and resets accounts when fetch fails', async () => {
+    const store = useAccountsStore()
+    const mockError = new Error('GetAll failed')
+    fetchWrapper.get.mockRejectedValueOnce(mockError)
+    await expect(store.getAll()).rejects.toThrow('GetAll failed')
+    expect(store.error).toBe(mockError)
+    expect(store.accounts).toEqual([])
+    expect(store.loading).toBe(false)
+  })
+
+  it('getById throws error and resets account when fetch fails', async () => {
+    const store = useAccountsStore()
+    const mockError = new Error('GetById failed')
+    fetchWrapper.get.mockRejectedValueOnce(mockError)
+    await expect(store.getById(1)).rejects.toThrow('GetById failed')
+    expect(store.error).toBe(mockError)
+    expect(store.account).toBe(null)
+    expect(store.loading).toBe(false)
+  })
+
+  it('update throws error and sets error state when fetch fails', async () => {
+    const store = useAccountsStore()
+    const mockError = new Error('Update failed')
+    fetchWrapper.put.mockRejectedValueOnce(mockError)
+    await expect(store.update(1, { name: 'Fail' })).rejects.toThrow('Update failed')
+    expect(store.error).toBe(mockError)
+    expect(store.loading).toBe(false)
+  })
+
+  it('delete throws error and sets error state when fetch fails', async () => {
+    const store = useAccountsStore()
+    const mockError = new Error('Delete failed')
+    fetchWrapper.delete.mockRejectedValueOnce(mockError)
+    await expect(store.delete(1)).rejects.toThrow('Delete failed')
+    expect(store.error).toBe(mockError)
+    expect(store.loading).toBe(false)
+  })
+})
+

--- a/tests/device.groups.store.spec.js
+++ b/tests/device.groups.store.spec.js
@@ -1,0 +1,141 @@
+// Copyright (c) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// This file is a part of Media Pi frontend application
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useDeviceGroupsStore } from '@/stores/device.groups.store.js'
+import { fetchWrapper } from '@/helpers/fetch.wrapper.js'
+
+vi.mock('@/helpers/fetch.wrapper.js', () => {
+  return {
+    fetchWrapper: {
+      get: vi.fn(),
+      post: vi.fn(),
+      put: vi.fn(),
+      delete: vi.fn(),
+      patch: vi.fn()
+    }
+  }
+})
+
+const mockGroups = [
+  { id: 1, name: 'Group 1' },
+  { id: 2, name: 'Group 2' }
+]
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  vi.clearAllMocks()
+})
+
+describe('device.groups.store', () => {
+  it('getGroupById returns correct group', () => {
+    const store = useDeviceGroupsStore()
+    store.$patch({ groups: mockGroups })
+
+    expect(store.getGroupById(1)).toEqual(mockGroups[0])
+    expect(store.getGroupById(999)).toBeUndefined()
+  })
+
+  it('add calls fetchWrapper.post', async () => {
+    const store = useDeviceGroupsStore()
+    fetchWrapper.post.mockResolvedValueOnce({})
+    await store.add({ name: 'Group 3' })
+    expect(fetchWrapper.post).toHaveBeenCalled()
+  })
+
+  it('getAll sets groups from fetch', async () => {
+    const store = useDeviceGroupsStore()
+    fetchWrapper.get.mockResolvedValueOnce(mockGroups)
+    await store.getAll()
+    expect(store.groups).toEqual(mockGroups)
+  })
+
+  it('getById sets group from fetch', async () => {
+    const store = useDeviceGroupsStore()
+    fetchWrapper.get.mockResolvedValueOnce(mockGroups[0])
+    await store.getById(1)
+    expect(store.group).toEqual(mockGroups[0])
+  })
+
+  it('update calls fetchWrapper.put', async () => {
+    const store = useDeviceGroupsStore()
+    fetchWrapper.put.mockResolvedValueOnce({})
+    await store.update(1, { name: 'Updated' })
+    expect(fetchWrapper.put).toHaveBeenCalled()
+  })
+
+  it('delete calls fetchWrapper.delete', async () => {
+    const store = useDeviceGroupsStore()
+    fetchWrapper.delete.mockResolvedValueOnce({})
+    await store.delete(1)
+    expect(fetchWrapper.delete).toHaveBeenCalled()
+  })
+
+  it('add throws error and sets error state when fetch fails', async () => {
+    const store = useDeviceGroupsStore()
+    const mockError = new Error('Add failed')
+    fetchWrapper.post.mockRejectedValueOnce(mockError)
+    await expect(store.add({ name: 'G' })).rejects.toThrow('Add failed')
+    expect(store.error).toBe(mockError)
+    expect(store.loading).toBe(false)
+  })
+
+  it('getAll throws error and resets groups when fetch fails', async () => {
+    const store = useDeviceGroupsStore()
+    const mockError = new Error('GetAll failed')
+    fetchWrapper.get.mockRejectedValueOnce(mockError)
+    await expect(store.getAll()).rejects.toThrow('GetAll failed')
+    expect(store.error).toBe(mockError)
+    expect(store.groups).toEqual([])
+    expect(store.loading).toBe(false)
+  })
+
+  it('getById throws error and resets group when fetch fails', async () => {
+    const store = useDeviceGroupsStore()
+    const mockError = new Error('GetById failed')
+    fetchWrapper.get.mockRejectedValueOnce(mockError)
+    await expect(store.getById(1)).rejects.toThrow('GetById failed')
+    expect(store.error).toBe(mockError)
+    expect(store.group).toBe(null)
+    expect(store.loading).toBe(false)
+  })
+
+  it('update throws error and sets error state when fetch fails', async () => {
+    const store = useDeviceGroupsStore()
+    const mockError = new Error('Update failed')
+    fetchWrapper.put.mockRejectedValueOnce(mockError)
+    await expect(store.update(1, { name: 'Fail' })).rejects.toThrow('Update failed')
+    expect(store.error).toBe(mockError)
+    expect(store.loading).toBe(false)
+  })
+
+  it('delete throws error and sets error state when fetch fails', async () => {
+    const store = useDeviceGroupsStore()
+    const mockError = new Error('Delete failed')
+    fetchWrapper.delete.mockRejectedValueOnce(mockError)
+    await expect(store.delete(1)).rejects.toThrow('Delete failed')
+    expect(store.error).toBe(mockError)
+    expect(store.loading).toBe(false)
+  })
+})
+

--- a/tests/devices.store.spec.js
+++ b/tests/devices.store.spec.js
@@ -1,0 +1,191 @@
+// Copyright (c) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// This file is a part of Media Pi frontend application
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useDevicesStore } from '@/stores/devices.store.js'
+import { fetchWrapper } from '@/helpers/fetch.wrapper.js'
+
+vi.mock('@/helpers/fetch.wrapper.js', () => {
+  return {
+    fetchWrapper: {
+      get: vi.fn(),
+      post: vi.fn(),
+      put: vi.fn(),
+      delete: vi.fn(),
+      patch: vi.fn()
+    }
+  }
+})
+
+const mockDevices = [
+  { id: 1, name: 'Device 1' },
+  { id: 2, name: 'Device 2' }
+]
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  vi.clearAllMocks()
+})
+
+describe('devices.store', () => {
+  it('getDeviceById returns correct device', () => {
+    const store = useDevicesStore()
+    store.$patch({ devices: mockDevices })
+
+    expect(store.getDeviceById(1)).toEqual(mockDevices[0])
+    expect(store.getDeviceById(999)).toBeUndefined()
+  })
+
+  it('register calls fetchWrapper.post', async () => {
+    const store = useDevicesStore()
+    fetchWrapper.post.mockResolvedValueOnce({ id: 3 })
+    const res = await store.register()
+    expect(fetchWrapper.post).toHaveBeenCalled()
+    expect(res).toEqual({ id: 3 })
+  })
+
+  it('getAll sets devices from fetch', async () => {
+    const store = useDevicesStore()
+    fetchWrapper.get.mockResolvedValueOnce(mockDevices)
+    await store.getAll()
+    expect(store.devices).toEqual(mockDevices)
+  })
+
+  it('getAllByAccount sets devices from fetch', async () => {
+    const store = useDevicesStore()
+    fetchWrapper.get.mockResolvedValueOnce(mockDevices)
+    await store.getAllByAccount(1)
+    expect(store.devices).toEqual(mockDevices)
+  })
+
+  it('getById sets device from fetch', async () => {
+    const store = useDevicesStore()
+    fetchWrapper.get.mockResolvedValueOnce(mockDevices[0])
+    await store.getById(1)
+    expect(store.device).toEqual(mockDevices[0])
+  })
+
+  it('update calls fetchWrapper.put', async () => {
+    const store = useDevicesStore()
+    fetchWrapper.put.mockResolvedValueOnce({})
+    await store.update(1, { name: 'Updated' })
+    expect(fetchWrapper.put).toHaveBeenCalled()
+  })
+
+  it('delete calls fetchWrapper.delete', async () => {
+    const store = useDevicesStore()
+    fetchWrapper.delete.mockResolvedValueOnce({})
+    await store.delete(1)
+    expect(fetchWrapper.delete).toHaveBeenCalled()
+  })
+
+  it('assignGroup calls fetchWrapper.patch', async () => {
+    const store = useDevicesStore()
+    fetchWrapper.patch.mockResolvedValueOnce({})
+    await store.assignGroup(1, { deviceGroupId: 2 })
+    expect(fetchWrapper.patch).toHaveBeenCalled()
+  })
+
+  it('initialAssignAccount calls fetchWrapper.patch', async () => {
+    const store = useDevicesStore()
+    fetchWrapper.patch.mockResolvedValueOnce({})
+    await store.initialAssignAccount(1, { accountId: 2 })
+    expect(fetchWrapper.patch).toHaveBeenCalled()
+  })
+
+  it('register throws error and sets error state when fetch fails', async () => {
+    const store = useDevicesStore()
+    const mockError = new Error('Register failed')
+    fetchWrapper.post.mockRejectedValueOnce(mockError)
+    await expect(store.register()).rejects.toThrow('Register failed')
+    expect(store.error).toBe(mockError)
+    expect(store.loading).toBe(false)
+  })
+
+  it('getAll throws error and resets devices when fetch fails', async () => {
+    const store = useDevicesStore()
+    const mockError = new Error('GetAll failed')
+    fetchWrapper.get.mockRejectedValueOnce(mockError)
+    await expect(store.getAll()).rejects.toThrow('GetAll failed')
+    expect(store.error).toBe(mockError)
+    expect(store.devices).toEqual([])
+    expect(store.loading).toBe(false)
+  })
+
+  it('getAllByAccount throws error and resets devices when fetch fails', async () => {
+    const store = useDevicesStore()
+    const mockError = new Error('GetAllByAccount failed')
+    fetchWrapper.get.mockRejectedValueOnce(mockError)
+    await expect(store.getAllByAccount(1)).rejects.toThrow('GetAllByAccount failed')
+    expect(store.error).toBe(mockError)
+    expect(store.devices).toEqual([])
+    expect(store.loading).toBe(false)
+  })
+
+  it('getById throws error and resets device when fetch fails', async () => {
+    const store = useDevicesStore()
+    const mockError = new Error('GetById failed')
+    fetchWrapper.get.mockRejectedValueOnce(mockError)
+    await expect(store.getById(1)).rejects.toThrow('GetById failed')
+    expect(store.error).toBe(mockError)
+    expect(store.device).toBe(null)
+    expect(store.loading).toBe(false)
+  })
+
+  it('update throws error and sets error state when fetch fails', async () => {
+    const store = useDevicesStore()
+    const mockError = new Error('Update failed')
+    fetchWrapper.put.mockRejectedValueOnce(mockError)
+    await expect(store.update(1, { name: 'Fail' })).rejects.toThrow('Update failed')
+    expect(store.error).toBe(mockError)
+    expect(store.loading).toBe(false)
+  })
+
+  it('delete throws error and sets error state when fetch fails', async () => {
+    const store = useDevicesStore()
+    const mockError = new Error('Delete failed')
+    fetchWrapper.delete.mockRejectedValueOnce(mockError)
+    await expect(store.delete(1)).rejects.toThrow('Delete failed')
+    expect(store.error).toBe(mockError)
+    expect(store.loading).toBe(false)
+  })
+
+  it('assignGroup throws error and sets error state when fetch fails', async () => {
+    const store = useDevicesStore()
+    const mockError = new Error('Assign failed')
+    fetchWrapper.patch.mockRejectedValueOnce(mockError)
+    await expect(store.assignGroup(1, { deviceGroupId: 2 })).rejects.toThrow('Assign failed')
+    expect(store.error).toBe(mockError)
+    expect(store.loading).toBe(false)
+  })
+
+  it('initialAssignAccount throws error and sets error state when fetch fails', async () => {
+    const store = useDevicesStore()
+    const mockError = new Error('InitialAssign failed')
+    fetchWrapper.patch.mockRejectedValueOnce(mockError)
+    await expect(store.initialAssignAccount(1, { accountId: 2 })).rejects.toThrow('InitialAssign failed')
+    expect(store.error).toBe(mockError)
+    expect(store.loading).toBe(false)
+  })
+})
+


### PR DESCRIPTION
## Summary
- add Pinia stores for accounts, device groups, and devices backed by new API controllers
- support PATCH requests in fetch wrapper
- cover new stores with extensive unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68966c6726588321810131d19fc9a7e6