### PR TITLE
feat: add hierarchical accounts tree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       run: npm run lint
 
     - name: Run tests
-      run: npm run test -- --run --coverage
+      run: npm run coverage
 
     - name: Upload results to Codecov
       uses: codecov/codecov-action@v5

--- a/src/App.vue
+++ b/src/App.vue
@@ -23,7 +23,7 @@
 
 import { RouterLink, RouterView } from 'vue-router'
 import { version } from '@/../package'
-import { onMounted, computed } from 'vue'
+import { onMounted } from 'vue'
 import { useStatusStore } from '@/stores/status.store.js'
 import { useAccountsCaption } from '@/helpers/accounts.caption.js'
 

--- a/src/components/Accounts_Tree.vue
+++ b/src/components/Accounts_Tree.vue
@@ -21,11 +21,73 @@
 // This file is a part of Media Pi frontend application
 
 <script setup>
-
+import { onMounted, ref, computed } from 'vue'
 import { useAccountsCaption } from '@/helpers/accounts.caption.js'
+import { useAuthStore } from '@/stores/auth.store.js'
+import { useAccountsStore } from '@/stores/accounts.store.js'
+import { useDevicesStore } from '@/stores/devices.store.js'
+import { useDeviceGroupsStore } from '@/stores/device.groups.store.js'
 
 const accountsCaption = useAccountsCaption()
+const authStore = useAuthStore()
+const accountsStore = useAccountsStore()
+const devicesStore = useDevicesStore()
+const deviceGroupsStore = useDeviceGroupsStore()
 
+const loading = ref(true)
+
+onMounted(async () => {
+  try {
+    await Promise.all([
+      accountsStore.getAll(),
+      devicesStore.getAll(),
+      deviceGroupsStore.getAll()
+    ])
+  } finally {
+    loading.value = false
+  }
+})
+
+const unassignedRoot = computed(() => {
+  if (!(authStore.isAdministrator || authStore.isEngineer)) return null
+  const children = (devicesStore.devices || [])
+    .filter(d => !d.accountId || d.accountId === 0)
+    .map(d => ({ id: `device-${d.id}`, name: d.name }))
+  return { id: 'root-unassigned', name: 'Нераспределённые устройства', children }
+})
+
+const accountsRoot = computed(() => {
+  if (!(authStore.isAdministrator || authStore.isManager)) return null
+  const accounts = (accountsStore.accounts || []).map(acc => {
+    const devices = (devicesStore.devices || []).filter(d => d.accountId === acc.id)
+    const unassigned = devices
+      .filter(d => !d.deviceGroupId || d.deviceGroupId === 0)
+      .map(d => ({ id: `device-${d.id}`, name: d.name }))
+    const groups = (deviceGroupsStore.groups || [])
+      .filter(g => g.accountId === acc.id)
+      .map(g => ({
+        id: `group-${g.id}`,
+        name: g.name,
+        children: devices
+          .filter(d => d.deviceGroupId === g.id)
+          .map(d => ({ id: `device-${d.id}`, name: d.name }))
+      }))
+    const children = []
+    if (unassigned.length > 0) {
+      children.push({ id: `account-${acc.id}-unassigned`, name: 'Нераспределённые устройства', children: unassigned })
+    }
+    children.push(...groups)
+    return { id: `account-${acc.id}`, name: acc.name, children }
+  })
+  return { id: 'root-accounts', name: 'Лицевые счета', children: accounts }
+})
+
+const treeItems = computed(() => {
+  const items = []
+  if (unassignedRoot.value) items.push(unassignedRoot.value)
+  if (accountsRoot.value) items.push(accountsRoot.value)
+  return items
+})
 </script>
 
 <template>
@@ -34,6 +96,14 @@ const accountsCaption = useAccountsCaption()
     <hr class="hr" />
 
     <v-card>
+      <v-treeview
+        v-if="!loading"
+        :items="treeItems"
+        item-title="name"
+        item-value="id"
+        open-on-click
+      />
     </v-card>
-    </div>
+  </div>
 </template>
+

--- a/src/components/Accounts_Tree.vue
+++ b/src/components/Accounts_Tree.vue
@@ -36,6 +36,15 @@ const deviceGroupsStore = useDeviceGroupsStore()
 
 const loading = ref(true)
 
+// Role-based access helper functions
+const canViewUnassignedDevices = computed(() => 
+  authStore.isAdministrator || authStore.isEngineer
+)
+
+const canViewAccounts = computed(() => 
+  authStore.isAdministrator || authStore.isManager
+)
+
 onMounted(async () => {
   try {
     await Promise.all([
@@ -49,7 +58,7 @@ onMounted(async () => {
 })
 
 const unassignedRoot = computed(() => {
-  if (!(authStore.isAdministrator || authStore.isEngineer)) return null
+  if (!canViewUnassignedDevices.value) return null
   const children = (devicesStore.devices || [])
     .filter(d => !d.accountId || d.accountId === 0)
     .map(d => ({ id: `device-${d.id}`, name: d.name }))
@@ -57,7 +66,7 @@ const unassignedRoot = computed(() => {
 })
 
 const accountsRoot = computed(() => {
-  if (!(authStore.isAdministrator || authStore.isManager)) return null
+  if (!canViewAccounts.value) return null
   const accounts = (accountsStore.accounts || []).map(acc => {
     const devices = (devicesStore.devices || []).filter(d => d.accountId === acc.id)
     const unassigned = devices

--- a/tests/Accounts_Tree.spec.js
+++ b/tests/Accounts_Tree.spec.js
@@ -1,0 +1,124 @@
+// Copyright (c) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// This file is a part of Media Pi frontend application
+
+/* @vitest-environment jsdom */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import AccountsTree from '@/components/Accounts_Tree.vue'
+import { resolveAll } from './helpers/test-utils'
+
+let authStore
+const accountsStore = {
+  accounts: [],
+  getAll: vi.fn().mockResolvedValue()
+}
+const devicesStore = {
+  devices: [],
+  getAll: vi.fn().mockResolvedValue()
+}
+const deviceGroupsStore = {
+  groups: [],
+  getAll: vi.fn().mockResolvedValue()
+}
+
+vi.mock('pinia', async () => {
+  const actual = await vi.importActual('pinia')
+  return { ...actual, storeToRefs: (store) => store }
+})
+
+vi.mock('@/stores/auth.store.js', () => ({
+  useAuthStore: () => authStore
+}))
+
+vi.mock('@/stores/accounts.store.js', () => ({
+  useAccountsStore: () => accountsStore
+}))
+
+vi.mock('@/stores/devices.store.js', () => ({
+  useDevicesStore: () => devicesStore
+}))
+
+vi.mock('@/stores/device.groups.store.js', () => ({
+  useDeviceGroupsStore: () => deviceGroupsStore
+}))
+
+const mountTree = () => mount(AccountsTree, {
+  global: {
+    stubs: {
+      'v-card': { template: '<div><slot /></div>' },
+      'v-treeview': { props: ['items'], template: '<div />' }
+    }
+  }
+})
+
+describe('Accounts_Tree.vue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    accountsStore.accounts = []
+    devicesStore.devices = []
+    deviceGroupsStore.groups = []
+  })
+
+  it('renders both roots for administrator', async () => {
+    authStore = { isAdministrator: true, isManager: false, isEngineer: false }
+    accountsStore.accounts = [
+      { id: 1, name: 'Account 1' }
+    ]
+    devicesStore.devices = [
+      { id: 1, name: 'Device A', accountId: 0 },
+      { id: 2, name: 'Device B', accountId: 1, deviceGroupId: 0 }
+    ]
+    const wrapper = mountTree()
+    await resolveAll()
+    expect(wrapper.vm.treeItems.length).toBe(2)
+    expect(wrapper.vm.treeItems[0].name).toBe('Нераспределённые устройства')
+    expect(wrapper.vm.treeItems[1].name).toBe('Лицевые счета')
+    expect(wrapper.vm.treeItems[1].children[0].name).toBe('Account 1')
+  })
+
+  it('shows only accounts for manager', async () => {
+    authStore = { isAdministrator: false, isManager: true, isEngineer: false }
+    accountsStore.accounts = [
+      { id: 1, name: 'Account 1' }
+    ]
+    devicesStore.devices = [
+      { id: 2, name: 'Device B', accountId: 1, deviceGroupId: 0 }
+    ]
+    const wrapper = mountTree()
+    await resolveAll()
+    expect(wrapper.vm.treeItems.length).toBe(1)
+    expect(wrapper.vm.treeItems[0].name).toBe('Лицевые счета')
+    expect(wrapper.vm.treeItems[0].children[0].children[0].name).toBe('Нераспределённые устройства')
+  })
+
+  it('shows only unassigned devices for engineer', async () => {
+    authStore = { isAdministrator: false, isManager: false, isEngineer: true }
+    devicesStore.devices = [
+      { id: 1, name: 'Device A', accountId: 0 }
+    ]
+    const wrapper = mountTree()
+    await resolveAll()
+    expect(wrapper.vm.treeItems.length).toBe(1)
+    expect(wrapper.vm.treeItems[0].name).toBe('Нераспределённые устройства')
+  })
+})
+


### PR DESCRIPTION
## Summary
- build accounts tree with device and group hierarchy
- show roots based on user role
- test tree rendering for admin, manager and engineer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68970928edc88321ab017bed3eab1dde