### PR TITLE
feat: add device group management forms

### DIFF
--- a/src/components/DeviceGroup_Settings.vue
+++ b/src/components/DeviceGroup_Settings.vue
@@ -1,0 +1,178 @@
+// Copyright (c) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// This file is a part of Media Pi frontend application
+
+<script setup>
+import { ref } from 'vue'
+import router from '@/router'
+import { storeToRefs } from 'pinia'
+import { Form, Field } from 'vee-validate'
+import * as Yup from 'yup'
+
+import { useDeviceGroupsStore } from '@/stores/device.groups.store.js'
+import { useAlertStore } from '@/stores/alert.store.js'
+import { redirectToDefaultRoute } from '@/helpers/default.route.js'
+
+const props = defineProps({
+  register: {
+    type: Boolean,
+    required: true
+  },
+  id: {
+    type: Number,
+    required: false
+  },
+  accountId: {
+    type: Number,
+    required: false
+  }
+})
+
+const deviceGroupsStore = useDeviceGroupsStore()
+const alertStore = useAlertStore()
+const { alert } = storeToRefs(alertStore)
+const { loading } = storeToRefs(deviceGroupsStore)
+
+const schema = Yup.object().shape({
+  name: Yup.string().required('Необходимо указать имя')
+})
+
+let group = ref({ name: '' })
+const componentError = ref(null)
+const initialLoading = ref(false)
+
+if (!isRegister()) {
+  initialLoading.value = true
+  try {
+    await deviceGroupsStore.getById(props.id)
+    const loadedGroup = deviceGroupsStore.group
+    if (!loadedGroup) {
+      throw new Error(`Группа устройств с ID ${props.id} не найдена`)
+    }
+    group.value = {
+      name: loadedGroup.name || ''
+    }
+  } catch (err) {
+    if (err.status === 401 || err.status === 403) {
+      redirectToDefaultRoute()
+    } else if (err.status === 404) {
+      componentError.value = `Группа устройств с ID ${props.id} не найдена`
+      alertStore.error(componentError.value)
+    } else {
+      componentError.value = err.message || err
+      alertStore.error(`Ошибка загрузки группы устройств: ${componentError.value}`)
+    }
+  } finally {
+    initialLoading.value = false
+  }
+}
+
+function isRegister () {
+  return props.register
+}
+
+function getButton () {
+  return isRegister() ? 'Создать' : 'Сохранить'
+}
+
+async function onSubmit (values) {
+  componentError.value = null
+  try {
+    const payload = {
+      name: values.name.trim()
+    }
+    if (isRegister()) {
+      payload.accountId = props.accountId
+      await deviceGroupsStore.add(payload)
+    } else {
+      await deviceGroupsStore.update(props.id, payload)
+    }
+    router.go(-1)
+  } catch (err) {
+    if (err.status === 401 || err.status === 403) {
+      redirectToDefaultRoute()
+    } else if (err.status === 404) {
+      componentError.value = `Группа устройств с ID ${props.id} не найдена`
+      alertStore.error(componentError.value)
+    } else if (err.status === 409) {
+      componentError.value = 'Группа устройств с таким названием уже существует'
+      alertStore.error(componentError.value)
+    } else if (err.status === 422) {
+      componentError.value = 'Проверьте корректность введённых данных'
+      alertStore.error(componentError.value)
+    } else {
+      componentError.value = err.message || err
+      alertStore.error(`Ошибка при ${isRegister() ? 'создании' : 'обновлении'} группы устройств: ${componentError.value}`)
+    }
+  }
+}
+</script>
+
+<template>
+  <div class="settings form-2 form-compact">
+    <h1 class="primary-heading">{{ isRegister() ? 'Новая группа устройств' : 'Настройки группы устройств' }}</h1>
+    <hr class="hr" />
+
+    <Form
+      :validation-schema="schema"
+      :initial-values="group"
+      @submit="onSubmit"
+      v-slot="{ errors, isSubmitting }"
+    >
+      <div class="form-group">
+        <label for="name" class="label">Название:</label>
+        <Field name="name" type="text" id="name" :disabled="isSubmitting"
+          class="form-control input" :class="{ 'is-invalid': errors.name }"
+          placeholder="Введите название группы"
+        />
+      </div>
+
+      <div class="form-group mt-8">
+        <button class="button primary" type="submit" :disabled="isSubmitting">
+          <span v-show="isSubmitting" class="spinner-border spinner-border-sm mr-1"></span>
+          <font-awesome-icon size="1x" icon="fa-solid fa-check-double" class="mr-1" />
+          {{ getButton() }}
+        </button>
+        <button
+          class="button secondary"
+          type="button"
+          @click="$router.go(-1)"
+        >
+          <font-awesome-icon size="1x" icon="fa-solid fa-xmark" class="mr-1" />
+          Отменить
+        </button>
+      </div>
+
+      <div v-if="errors.name" class="alert alert-danger mt-3 mb-0">{{ errors.name }}</div>
+    </Form>
+
+    <div v-if="alert" class="alert alert-dismissable mt-3 mb-0" :class="alert.type">
+      <button @click="alertStore.clear()" class="btn btn-link close">×</button>
+      {{ alert.message }}
+    </div>
+
+    <div v-if="loading || initialLoading" class="text-center m-5">
+      <span class="spinner-border spinner-border-lg align-center"></span>
+      <div class="mt-2">{{ loading ? 'Сохранение...' : 'Загрузка...' }}</div>
+    </div>
+  </div>
+</template>
+

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -96,6 +96,18 @@ const router = createRouter({
       name: 'Настройки',
       component: () => import('@/views/User_EditView.vue'),
       props: true
+    },
+    {
+      path: '/devicegroup/create/:accountId',
+      name: 'Создание группы устройств',
+      component: () => import('@/views/DeviceGroup_CreateView.vue'),
+      props: true
+    },
+    {
+      path: '/devicegroup/edit/:id',
+      name: 'Настройки группы устройств',
+      component: () => import('@/views/DeviceGroup_EditView.vue'),
+      props: true
     }
   ]
 })
@@ -153,6 +165,18 @@ router.beforeEach(async (to) => {
   }
 
   if (to.path.startsWith('/account/edit/')) {
+    if (!auth.isAdministrator && !auth.isManager) {
+      return '/'
+    }
+  }
+
+  if (to.path.startsWith('/devicegroup/create/')) {
+    if (!auth.isAdministrator && !auth.isManager) {
+      return '/'
+    }
+  }
+
+  if (to.path.startsWith('/devicegroup/edit/')) {
     if (!auth.isAdministrator && !auth.isManager) {
       return '/'
     }

--- a/src/views/DeviceGroup_CreateView.vue
+++ b/src/views/DeviceGroup_CreateView.vue
@@ -1,0 +1,46 @@
+// Copyright (c) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// This file is a part of Media Pi frontend application
+
+<script setup>
+import DeviceGroupSettings from '@/components/DeviceGroup_Settings.vue'
+
+const props = defineProps({
+  accountId: {
+    type: String,
+    required: true
+  }
+})
+const accountId = parseInt(props.accountId, 10)
+</script>
+
+<template>
+  <Suspense>
+    <DeviceGroupSettings :register="true" :accountId="accountId" />
+    <template #fallback>
+      <div class="text-center m-5">
+        <span class="spinner-border spinner-border-lg align-center"></span>
+        <div class="mt-2">Подготовка формы создания группы устройств...</div>
+      </div>
+    </template>
+  </Suspense>
+</template>
+

--- a/src/views/DeviceGroup_EditView.vue
+++ b/src/views/DeviceGroup_EditView.vue
@@ -1,0 +1,46 @@
+// Copyright (c) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// This file is a part of Media Pi frontend application
+
+<script setup>
+import DeviceGroupSettings from '@/components/DeviceGroup_Settings.vue'
+
+const props = defineProps({
+  id: {
+    type: String,
+    required: true
+  }
+})
+const id = parseInt(props.id, 10)
+</script>
+
+<template>
+  <Suspense>
+    <DeviceGroupSettings :register="false" :id="id" />
+    <template #fallback>
+      <div class="text-center m-5">
+        <span class="spinner-border spinner-border-lg align-center"></span>
+        <div class="mt-2">Загрузка информации о группе устройств...</div>
+      </div>
+    </template>
+  </Suspense>
+</template>
+

--- a/tests/DeviceGroup_Settings.spec.js
+++ b/tests/DeviceGroup_Settings.spec.js
@@ -1,0 +1,198 @@
+// Copyright (c) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// This file is a part of Media Pi frontend application
+
+import { library } from '@fortawesome/fontawesome-svg-core'
+import { faCheckDouble, faXmark } from '@fortawesome/free-solid-svg-icons'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
+import DeviceGroupSettings from '@/components/DeviceGroup_Settings.vue'
+
+library.add(faCheckDouble, faXmark)
+
+let authStore
+const deviceGroupsStore = {
+  group: null,
+  loading: false,
+  error: null,
+  getById: vi.fn(),
+  add: vi.fn(),
+  update: vi.fn()
+}
+const alertStore = {
+  error: vi.fn(),
+  success: vi.fn(),
+  clear: vi.fn()
+}
+
+vi.mock('pinia', async () => {
+  const actual = await vi.importActual('pinia')
+  return { ...actual, storeToRefs: (store) => store }
+})
+
+vi.mock('@/router', () => {
+  const mockGo = vi.fn()
+  return {
+    default: {
+      go: mockGo
+    }
+  }
+})
+
+vi.mock('@/stores/auth.store.js', () => ({
+  useAuthStore: () => authStore
+}))
+
+vi.mock('@/stores/device.groups.store.js', () => ({
+  useDeviceGroupsStore: () => deviceGroupsStore
+}))
+
+vi.mock('@/stores/alert.store.js', () => ({
+  useAlertStore: () => alertStore
+}))
+
+vi.mock('@/helpers/default.route.js', () => ({
+  redirectToDefaultRoute: vi.fn()
+}))
+
+const mountSettings = (props = {}) => mount({
+  template: '<Suspense><DeviceGroupSettings v-bind="$attrs" /></Suspense>',
+  components: { DeviceGroupSettings },
+  inheritAttrs: false
+}, {
+  attrs: {
+    register: false,
+    id: 1,
+    accountId: 1,
+    ...props
+  },
+  global: {
+    stubs: {
+      Form: {
+        template: '<div data-testid="form" @submit="onSubmit"><slot :errors="{}" :isSubmitting="false" /></div>',
+        props: ['validation-schema', 'initial-values'],
+        emits: ['submit'],
+        methods: {
+          onSubmit () {
+            this.$emit('submit', { name: 'Test Group' })
+          }
+        }
+      },
+      Field: { template: '<input />', props: ['name', 'type'] }
+    },
+    components: {
+      'font-awesome-icon': FontAwesomeIcon
+    }
+  }
+})
+
+describe('DeviceGroup_Settings.vue', () => {
+  beforeEach(() => {
+    authStore = {
+      isAdministrator: true,
+      isManager: false
+    }
+    deviceGroupsStore.group = null
+    deviceGroupsStore.loading = false
+    deviceGroupsStore.error = null
+    deviceGroupsStore.getById = vi.fn().mockResolvedValue()
+    deviceGroupsStore.add = vi.fn().mockResolvedValue()
+    deviceGroupsStore.update = vi.fn().mockResolvedValue()
+    vi.clearAllMocks()
+  })
+
+  it('renders form for creating new group', async () => {
+    const wrapper = mountSettings({ register: true, accountId: 5 })
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="form"]').exists()).toBe(true)
+    expect(deviceGroupsStore.getById).not.toHaveBeenCalled()
+  })
+
+  it('loads group data when editing', async () => {
+    deviceGroupsStore.group = {
+      id: 1,
+      name: 'Test Group'
+    }
+
+    const wrapper = mountSettings({ register: false, id: 1 })
+    await flushPromises()
+
+    expect(deviceGroupsStore.getById).toHaveBeenCalledWith(1)
+    expect(wrapper.find('[data-testid="form"]').exists()).toBe(true)
+  })
+
+  it('handles form submission for creating group', async () => {
+    const wrapper = mountSettings({ register: true, accountId: 5 })
+    await flushPromises()
+
+    const form = wrapper.find('[data-testid="form"]')
+    await form.trigger('submit')
+    await flushPromises()
+
+    expect(deviceGroupsStore.add).toHaveBeenCalledWith({
+      name: 'Test Group',
+      accountId: 5
+    })
+  })
+
+  it('handles form submission for updating group', async () => {
+    deviceGroupsStore.group = {
+      id: 1,
+      name: 'Existing Group'
+    }
+
+    const wrapper = mountSettings({ register: false, id: 1 })
+    await flushPromises()
+
+    const form = wrapper.find('[data-testid="form"]')
+    await form.trigger('submit')
+    await flushPromises()
+
+    expect(deviceGroupsStore.update).toHaveBeenCalledWith(1, {
+      name: 'Test Group'
+    })
+  })
+
+  it('handles group not found error', async () => {
+    deviceGroupsStore.group = null
+
+    mountSettings({ register: false, id: 999 })
+    await flushPromises()
+
+    expect(alertStore.error).toHaveBeenCalledWith('Ошибка загрузки группы устройств: Группа устройств с ID 999 не найдена')
+  })
+
+  it('handles create error', async () => {
+    deviceGroupsStore.add = vi.fn().mockRejectedValue({ message: 'Group name already exists' })
+
+    const wrapper = mountSettings({ register: true })
+    await flushPromises()
+
+    const form = wrapper.find('[data-testid="form"]')
+    await form.trigger('submit')
+    await flushPromises()
+
+    expect(alertStore.error).toHaveBeenCalledWith('Ошибка при создании группы устройств: Group name already exists')
+  })
+})
+

--- a/tests/router.spec.js
+++ b/tests/router.spec.js
@@ -41,6 +41,8 @@ vi.mock('@/views/User_RegisterView.vue', () => ({ default: { template: '<div />'
 vi.mock('@/views/Users_View.vue', () => ({ default: { template: '<div />' } }))
 vi.mock('@/views/User_EditView.vue', () => ({ default: { template: '<div />' } }))
 vi.mock('@/views/Accounts_View.vue', () => ({ default: { template: '<div />' } }))
+vi.mock('@/views/DeviceGroup_CreateView.vue', () => ({ default: { template: '<div />' } }))
+vi.mock('@/views/DeviceGroup_EditView.vue', () => ({ default: { template: '<div />' } }))
 
 import router from '@/router'
 


### PR DESCRIPTION
## Summary
- add DeviceGroup_Settings component with validation and CRUD support
- create DeviceGroup_CreateView and DeviceGroup_EditView
- expose device group routes with role guards
- cover device group settings with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cdeee8fd883218cb8201c2a079481