### PR TITLE
feat: add device settings views and tests

### DIFF
--- a/src/components/Device_Settings.vue
+++ b/src/components/Device_Settings.vue
@@ -1,0 +1,207 @@
+// Copyright (c) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// This file is a part of Media Pi frontend application
+
+<script setup>
+import { ref } from 'vue'
+import router from '@/router'
+import { storeToRefs } from 'pinia'
+import { Form, Field } from 'vee-validate'
+import * as Yup from 'yup'
+
+import { useDevicesStore } from '@/stores/devices.store.js'
+import { useAlertStore } from '@/stores/alert.store.js'
+import { useAuthStore } from '@/stores/auth.store.js'
+import { redirectToDefaultRoute } from '@/helpers/default.route.js'
+
+const props = defineProps({
+  register: {
+    type: Boolean,
+    required: true
+  },
+  id: {
+    type: Number,
+    required: false
+  },
+  accountId: {
+    type: Number,
+    required: false
+  }
+})
+
+const devicesStore = useDevicesStore()
+const alertStore = useAlertStore()
+const authStore = useAuthStore()
+const { alert } = storeToRefs(alertStore)
+const { loading } = storeToRefs(devicesStore)
+
+const schema = Yup.object().shape({
+  name: Yup.string().required('Необходимо указать имя'),
+  ipAddress: Yup.string().required('Необходимо указать IP адрес')
+})
+
+let device = ref({ name: '', ipAddress: '' })
+const initialLoading = ref(false)
+
+function canCreate () {
+  return authStore.isAdministrator || authStore.isEngineer
+}
+
+function canEdit (dev) {
+  if (authStore.isAdministrator || authStore.isManager) {
+    return true
+  }
+  return authStore.isEngineer && (dev?.accountId === null || dev?.accountId === undefined)
+}
+
+if (props.register) {
+  if (!canCreate()) {
+    redirectToDefaultRoute()
+  }
+} else {
+  initialLoading.value = true
+  try {
+    await devicesStore.getById(props.id)
+    const loadedDevice = devicesStore.device
+    if (!loadedDevice) {
+      throw new Error(`Устройство с ID ${props.id} не найдено`)
+    }
+    if (!canEdit(loadedDevice)) {
+      redirectToDefaultRoute()
+    }
+    device.value = {
+      name: loadedDevice.name || '',
+      ipAddress: loadedDevice.ipAddress || ''
+    }
+  } catch (err) {
+    if (err.status === 401 || err.status === 403) {
+      redirectToDefaultRoute()
+    } else if (err.status === 404) {
+      alertStore.error(`Устройство с ID ${props.id} не найдено`)
+    } else {
+      const errorMessage = err.message || err
+      alertStore.error(`Ошибка загрузки устройства: ${errorMessage}`)
+    }
+  } finally {
+    initialLoading.value = false
+  }
+}
+
+function isRegister () {
+  return props.register
+}
+
+function getButton () {
+  return isRegister() ? 'Создать' : 'Сохранить'
+}
+
+async function onSubmit (values) {
+  try {
+    const payload = {
+      name: values.name.trim(),
+      ipAddress: values.ipAddress.trim()
+    }
+    if (props.accountId !== undefined) {
+      payload.accountId = props.accountId
+    }
+    if (isRegister()) {
+      const reference = await devicesStore.register()
+      await devicesStore.update(reference.id, payload)
+    } else {
+      await devicesStore.update(props.id, payload)
+    }
+    router.go(-1)
+  } catch (err) {
+    if (err.status === 401 || err.status === 403) {
+      redirectToDefaultRoute()
+    } else if (err.status === 404) {
+      alertStore.error(`Устройство с ID ${props.id} не найдено`)
+    } else if (err.status === 409) {
+      alertStore.error('Устройство с таким IP адресом уже существует')
+    } else if (err.status === 422) {
+      alertStore.error('Проверьте корректность введённых данных')
+    } else {
+      const errorMessage = err.message || err
+      alertStore.error(`Ошибка при ${isRegister() ? 'создании' : 'обновлении'} устройства: ${errorMessage}`)
+    }
+  }
+}
+</script>
+
+<template>
+  <div class="settings form-2 form-compact">
+    <h1 class="primary-heading">{{ isRegister() ? 'Новое устройство' : 'Настройки устройства' }}</h1>
+    <hr class="hr" />
+
+    <Form
+      :validation-schema="schema"
+      :initial-values="device"
+      @submit="onSubmit"
+      v-slot="{ errors, isSubmitting }"
+    >
+      <div class="form-group">
+        <label for="name" class="label">Название:</label>
+        <Field name="name" type="text" id="name" :disabled="isSubmitting"
+          class="form-control input" :class="{ 'is-invalid': errors.name }"
+          placeholder="Введите название устройства"
+        />
+      </div>
+
+      <div class="form-group mt-4">
+        <label for="ipAddress" class="label">IP адрес:</label>
+        <Field name="ipAddress" type="text" id="ipAddress" :disabled="isSubmitting"
+          class="form-control input" :class="{ 'is-invalid': errors.ipAddress }"
+          placeholder="Введите IP адрес устройства"
+        />
+      </div>
+
+      <div class="form-group mt-8">
+        <button class="button primary" type="submit" :disabled="isSubmitting">
+          <span v-show="isSubmitting" class="spinner-border spinner-border-sm mr-1"></span>
+          <font-awesome-icon size="1x" icon="fa-solid fa-check-double" class="mr-1" />
+          {{ getButton() }}
+        </button>
+        <button
+          class="button secondary"
+          type="button"
+          @click="$router.go(-1)"
+        >
+          <font-awesome-icon size="1x" icon="fa-solid fa-xmark" class="mr-1" />
+          Отменить
+        </button>
+      </div>
+
+      <div v-if="errors.name" class="alert alert-danger mt-3 mb-0">{{ errors.name }}</div>
+      <div v-if="errors.ipAddress" class="alert alert-danger mt-3 mb-0">{{ errors.ipAddress }}</div>
+    </Form>
+
+    <div v-if="alert" class="alert alert-dismissable mt-3 mb-0" :class="alert.type">
+      <button @click="alertStore.clear()" class="btn btn-link close">×</button>
+      {{ alert.message }}
+    </div>
+
+    <div v-if="loading || initialLoading" class="text-center m-5">
+      <span class="spinner-border spinner-border-lg align-center"></span>
+      <div class="mt-2">{{ loading ? 'Сохранение...' : 'Загрузка...' }}</div>
+    </div>
+  </div>
+</template>
+

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -108,6 +108,18 @@ const router = createRouter({
       name: 'Настройки группы устройств',
       component: () => import('@/views/DeviceGroup_EditView.vue'),
       props: true
+    },
+    {
+      path: '/device/create/:accountId',
+      name: 'Создание устройства',
+      component: () => import('@/views/Device_CreateView.vue'),
+      props: true
+    },
+    {
+      path: '/device/edit/:id',
+      name: 'Настройки устройства',
+      component: () => import('@/views/Device_EditView.vue'),
+      props: true
     }
   ]
 })
@@ -178,6 +190,18 @@ router.beforeEach(async (to) => {
 
   if (to.path.startsWith('/devicegroup/edit/')) {
     if (!auth.isAdministrator && !auth.isManager) {
+      return '/'
+    }
+  }
+
+  if (to.path.startsWith('/device/create/')) {
+    if (!auth.isAdministrator && !auth.isEngineer) {
+      return '/'
+    }
+  }
+
+  if (to.path.startsWith('/device/edit/')) {
+    if (!auth.isAdministrator && !auth.isManager && !auth.isEngineer) {
       return '/'
     }
   }

--- a/src/views/Device_CreateView.vue
+++ b/src/views/Device_CreateView.vue
@@ -1,0 +1,46 @@
+// Copyright (c) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// This file is a part of Media Pi frontend application
+
+<script setup>
+import DeviceSettings from '@/components/Device_Settings.vue'
+
+const props = defineProps({
+  accountId: {
+    type: String,
+    required: true
+  }
+})
+const accountId = parseInt(props.accountId, 10)
+</script>
+
+<template>
+  <Suspense>
+    <DeviceSettings :register="true" :accountId="accountId" />
+    <template #fallback>
+      <div class="text-center m-5">
+        <span class="spinner-border spinner-border-lg align-center"></span>
+        <div class="mt-2">Подготовка формы создания устройства...</div>
+      </div>
+    </template>
+  </Suspense>
+</template>
+

--- a/src/views/Device_EditView.vue
+++ b/src/views/Device_EditView.vue
@@ -1,0 +1,46 @@
+// Copyright (c) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// This file is a part of Media Pi frontend application
+
+<script setup>
+import DeviceSettings from '@/components/Device_Settings.vue'
+
+const props = defineProps({
+  id: {
+    type: String,
+    required: true
+  }
+})
+const id = parseInt(props.id, 10)
+</script>
+
+<template>
+  <Suspense>
+    <DeviceSettings :register="false" :id="id" />
+    <template #fallback>
+      <div class="text-center m-5">
+        <span class="spinner-border spinner-border-lg align-center"></span>
+        <div class="mt-2">Загрузка информации об устройстве...</div>
+      </div>
+    </template>
+  </Suspense>
+</template>
+

--- a/tests/Device_Settings.spec.js
+++ b/tests/Device_Settings.spec.js
@@ -1,0 +1,181 @@
+// Copyright (c) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// This file is a part of Media Pi frontend application
+
+import { library } from '@fortawesome/fontawesome-svg-core'
+import { faCheckDouble, faXmark } from '@fortawesome/free-solid-svg-icons'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
+import DeviceSettings from '@/components/Device_Settings.vue'
+
+library.add(faCheckDouble, faXmark)
+
+let authStore
+const devicesStore = {
+  device: null,
+  loading: false,
+  getById: vi.fn(),
+  register: vi.fn(),
+  update: vi.fn()
+}
+const alertStore = {
+  alert: null,
+  error: vi.fn(),
+  clear: vi.fn()
+}
+
+vi.mock('pinia', async () => {
+  const actual = await vi.importActual('pinia')
+  return { ...actual, storeToRefs: (store) => store }
+})
+
+vi.mock('@/router', () => ({
+  default: { go: vi.fn() },
+  $router: { go: vi.fn() }
+}))
+
+vi.mock('@/stores/auth.store.js', () => ({
+  useAuthStore: () => authStore
+}))
+
+vi.mock('@/stores/devices.store.js', () => ({
+  useDevicesStore: () => devicesStore
+}))
+
+vi.mock('@/stores/alert.store.js', () => ({
+  useAlertStore: () => alertStore
+}))
+
+vi.mock('@/helpers/default.route.js', () => ({
+  redirectToDefaultRoute: vi.fn()
+}))
+
+const mountSettings = (props = {}) => mount({
+  template: '<Suspense><DeviceSettings v-bind="$attrs" /></Suspense>',
+  components: { DeviceSettings },
+  inheritAttrs: false
+}, {
+  attrs: {
+    register: false,
+    id: 1,
+    accountId: 1,
+    ...props
+  },
+  global: {
+    stubs: {
+      Form: {
+        template: `
+          <div data-testid="form" @submit="onSubmit">
+            <slot :errors="errors" :isSubmitting="isSubmitting" />
+          </div>
+        `,
+        props: ['validation-schema', 'initial-values'],
+        emits: ['submit'],
+        data() {
+          return {
+            errors: props.showValidationError ? { name: 'Необходимо указать имя', ipAddress: 'Необходимо указать IP адрес' } : {},
+            isSubmitting: props.isSubmitting || false
+          }
+        },
+        methods: {
+          onSubmit() {
+            this.$emit('submit', { name: props.submitName || 'Test Device', ipAddress: props.submitIp || '1.2.3.4' })
+          }
+        }
+      },
+      Field: {
+        template: '<input />',
+        props: ['name', 'type', 'disabled', 'class', 'placeholder']
+      }
+    },
+    components: {
+      'font-awesome-icon': FontAwesomeIcon
+    }
+  }
+})
+
+beforeEach(() => {
+  authStore = { isAdministrator: true, isEngineer: false, isManager: false, user: { id: 1 } }
+  devicesStore.device = null
+  devicesStore.getById.mockReset()
+  devicesStore.register.mockReset()
+  devicesStore.update.mockReset()
+  alertStore.error.mockReset()
+})
+
+describe('Device_Settings.vue', () => {
+  it('submits create form and calls register and update', async () => {
+    devicesStore.register.mockResolvedValue({ id: 5 })
+    devicesStore.update.mockResolvedValue()
+
+    const wrapper = mountSettings({ register: true, accountId: 3 })
+    await flushPromises()
+
+    const form = wrapper.find('[data-testid="form"]')
+    await form.trigger('submit')
+    await flushPromises()
+
+    expect(devicesStore.register).toHaveBeenCalled()
+    expect(devicesStore.update).toHaveBeenCalledWith(5, expect.objectContaining({ name: 'Test Device', ipAddress: '1.2.3.4', accountId: 3 }))
+  })
+
+  it('loads device and submits update', async () => {
+    devicesStore.device = { id: 1, name: 'Old', ipAddress: '0.0.0.0', accountId: null }
+    devicesStore.getById.mockResolvedValue()
+    devicesStore.update.mockResolvedValue()
+
+    const wrapper = mountSettings({ register: false, id: 1 })
+    await flushPromises()
+
+    const form = wrapper.find('[data-testid="form"]')
+    await form.trigger('submit')
+    await flushPromises()
+
+    expect(devicesStore.getById).toHaveBeenCalledWith(1)
+    expect(devicesStore.update).toHaveBeenCalledWith(1, expect.objectContaining({ name: 'Test Device', ipAddress: '1.2.3.4' }))
+  })
+
+  it('redirects when creating without permission', async () => {
+    const { redirectToDefaultRoute } = await import('@/helpers/default.route.js')
+    authStore.isAdministrator = false
+    authStore.isEngineer = false
+
+    mountSettings({ register: true, accountId: 5 })
+    await flushPromises()
+
+    expect(redirectToDefaultRoute).toHaveBeenCalled()
+  })
+
+  it('redirects engineer editing device with account', async () => {
+    const { redirectToDefaultRoute } = await import('@/helpers/default.route.js')
+    authStore.isAdministrator = false
+    authStore.isEngineer = true
+    devicesStore.device = { id: 1, name: 'Old', ipAddress: '0.0.0.0', accountId: 2 }
+    devicesStore.getById.mockResolvedValue()
+
+    mountSettings({ register: false, id: 1 })
+    await flushPromises()
+
+    expect(redirectToDefaultRoute).toHaveBeenCalled()
+  })
+})
+

--- a/tests/router.spec.js
+++ b/tests/router.spec.js
@@ -43,6 +43,8 @@ vi.mock('@/views/User_EditView.vue', () => ({ default: { template: '<div />' } }
 vi.mock('@/views/Accounts_View.vue', () => ({ default: { template: '<div />' } }))
 vi.mock('@/views/DeviceGroup_CreateView.vue', () => ({ default: { template: '<div />' } }))
 vi.mock('@/views/DeviceGroup_EditView.vue', () => ({ default: { template: '<div />' } }))
+vi.mock('@/views/Device_CreateView.vue', () => ({ default: { template: '<div />' } }))
+vi.mock('@/views/Device_EditView.vue', () => ({ default: { template: '<div />' } }))
 
 import router from '@/router'
 


### PR DESCRIPTION
## Summary
- add Device_Settings form with create/edit permissions and device registration
- introduce Device_CreateView and Device_EditView
- extend router with device routes and guards
- cover device form with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cf5762bf483218fe2bfae07317713