### PR TITLE
Add front-end support for device service management

### DIFF
--- a/src/stores/devices.store.js
+++ b/src/stores/devices.store.js
@@ -30,8 +30,17 @@ const baseUrl = `${apiUrl}/devices`
 export const useDevicesStore = defineStore('devices', () => {
   const devices = ref([])
   const device = ref(null)
+  const services = ref([])
+  const serviceResponse = ref(null)
   const loading = ref(false)
   const error = ref(null)
+
+  const sanitizeServiceUnit = (unit) => {
+    if (typeof unit !== 'string') {
+      return ''
+    }
+    return unit.trim()
+  }
 
   const getDeviceById = (id) => {
     if (!devices.value || !Array.isArray(devices.value)) {
@@ -101,6 +110,70 @@ export const useDevicesStore = defineStore('devices', () => {
     }
   }
 
+  async function listServices(id) {
+    loading.value = true
+    error.value = null
+    try {
+      const result = await fetchWrapper.get(`${baseUrl}/${id}/services`)
+      const units = Array.isArray(result?.units) ? result.units : []
+      services.value = units
+      serviceResponse.value = result
+      return result
+    } catch (err) {
+      error.value = err
+      services.value = []
+      serviceResponse.value = null
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function executeServiceAction(id, unit, action) {
+    loading.value = true
+    error.value = null
+    try {
+      const sanitizedUnit = sanitizeServiceUnit(unit)
+      if (!sanitizedUnit) {
+        const validationError = new Error('Не указано имя службы')
+        validationError.status = 400
+        throw validationError
+      }
+      const result = await fetchWrapper.post(
+        `${baseUrl}/${id}/services/${encodeURIComponent(sanitizedUnit)}/${action}`,
+        {}
+      )
+      serviceResponse.value = result
+      return result
+    } catch (err) {
+      error.value = err
+      serviceResponse.value = null
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function startService(id, unit) {
+    return executeServiceAction(id, unit, 'start')
+  }
+
+  async function stopService(id, unit) {
+    return executeServiceAction(id, unit, 'stop')
+  }
+
+  async function restartService(id, unit) {
+    return executeServiceAction(id, unit, 'restart')
+  }
+
+  async function enableService(id, unit) {
+    return executeServiceAction(id, unit, 'enable')
+  }
+
+  async function disableService(id, unit) {
+    return executeServiceAction(id, unit, 'disable')
+  }
+
   async function update(id, params) {
     loading.value = true
     error.value = null
@@ -162,6 +235,8 @@ export const useDevicesStore = defineStore('devices', () => {
   return {
     devices,
     device,
+    services,
+    serviceResponse,
     loading,
     error,
     getDeviceById,
@@ -169,10 +244,16 @@ export const useDevicesStore = defineStore('devices', () => {
     getAll,
     getByAccount,
     getById,
+    listServices,
     update,
     delete: deleteDevice,
     assignGroup,
-    assignAccount
+    assignAccount,
+    startService,
+    stopService,
+    restartService,
+    enableService,
+    disableService
   }
 })
 

--- a/tests/devices.store.spec.js
+++ b/tests/devices.store.spec.js
@@ -227,5 +227,88 @@ describe('devices.store', () => {
       { Id: 3 }
     )
   })
+
+  it('listServices updates services and serviceResponse', async () => {
+    const store = useDevicesStore()
+    const mockResponse = {
+      ok: true,
+      units: [
+        { unit: 'one', active: 'active', sub: 'running' },
+        { unit: 'two', active: 'inactive', sub: 'dead' }
+      ]
+    }
+    fetchWrapper.get.mockResolvedValueOnce(mockResponse)
+
+    const result = await store.listServices(5)
+
+    expect(fetchWrapper.get).toHaveBeenCalledWith(expect.stringContaining('/devices/5/services'))
+    expect(store.services).toEqual(mockResponse.units)
+    expect(store.serviceResponse).toEqual(mockResponse)
+    expect(result).toEqual(mockResponse)
+  })
+
+  it('listServices resets state on error', async () => {
+    const store = useDevicesStore()
+    const mockError = new Error('List failed')
+    fetchWrapper.get.mockRejectedValueOnce(mockError)
+
+    await expect(store.listServices(6)).rejects.toThrow('List failed')
+    expect(store.error).toBe(mockError)
+    expect(store.services).toEqual([])
+    expect(store.serviceResponse).toBe(null)
+  })
+
+  it.each([
+    ['startService', 'start'],
+    ['stopService', 'stop'],
+    ['restartService', 'restart'],
+    ['enableService', 'enable'],
+    ['disableService', 'disable']
+  ])('%s posts to the correct endpoint and updates response', async (method, action) => {
+    const store = useDevicesStore()
+    const mockResult = { ok: true, unit: 'media-pi.service', result: 'done' }
+    fetchWrapper.post.mockResolvedValueOnce(mockResult)
+
+    const returned = await store[method](10, ' media-pi.service ')
+
+    expect(fetchWrapper.post).toHaveBeenCalledWith(
+      expect.stringContaining(`/devices/10/services/media-pi.service/${action}`),
+      {}
+    )
+    expect(store.serviceResponse).toEqual(mockResult)
+    expect(returned).toEqual(mockResult)
+  })
+
+  it('service commands URL-encode unit names', async () => {
+    const store = useDevicesStore()
+    fetchWrapper.post.mockResolvedValueOnce({ ok: true })
+
+    await store.startService(3, 'my service@1.service')
+
+    expect(fetchWrapper.post).toHaveBeenCalledWith(
+      expect.stringContaining('/devices/3/services/my%20service%401.service/start'),
+      {}
+    )
+  })
+
+  it('service commands validate unit name before sending request', async () => {
+    const store = useDevicesStore()
+
+    await expect(store.startService(4, '   ')).rejects.toThrow('Не указано имя службы')
+    expect(fetchWrapper.post).not.toHaveBeenCalled()
+    expect(store.error).toBeInstanceOf(Error)
+    expect(store.serviceResponse).toBe(null)
+  })
+
+  it('service commands reset state when fetch fails', async () => {
+    const store = useDevicesStore()
+    const mockError = new Error('Command failed')
+    fetchWrapper.post.mockRejectedValueOnce(mockError)
+
+    await expect(store.stopService(7, 'media-pi.service')).rejects.toThrow('Command failed')
+    expect(fetchWrapper.post).toHaveBeenCalled()
+    expect(store.error).toBe(mockError)
+    expect(store.serviceResponse).toBe(null)
+  })
 })
 


### PR DESCRIPTION
## Summary
- extend the devices store with service listing and control actions for the new backend endpoints
- track device service responses and reuse validation to keep request payloads consistent with the API
- expand the devices store test suite to cover listing, command execution, and error handling for services

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cdb748313c8321aacf4309c9670df2