### PR TITLE
Add device services list to status dialog

### DIFF
--- a/src/components/Device_Status_Dialog.vue
+++ b/src/components/Device_Status_Dialog.vue
@@ -6,6 +6,7 @@ import { computed, watch, ref } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useDevicesStore } from '@/stores/devices.store.js'
 import { useDeviceStatusesStore } from '@/stores/device.statuses.store.js'
+import ServicesList from '@/components/Services_List.vue'
 
 const props = defineProps({
   modelValue: { type: Boolean, required: true },
@@ -42,6 +43,7 @@ const status = computed(() => {
 const device = computed(() => devicesStore.getDeviceById(props.deviceId))
 
 const onlineClass = computed(() => status.value?.isOnline ? 'text-success' : 'text-danger')
+const isAccessible = computed(() => Boolean(status.value?.isOnline))
 
 function fmtDate(value) {
   if (!value) return '—'
@@ -109,6 +111,11 @@ watch(() => props.deviceId, () => {
           <div class="label">Задержка SSH</div>
           <div class="value">{{ status?.totalLatencyMs ?? '—' }} мс</div>
         </div>
+        <ServicesList
+          :device-id="props.deviceId"
+          :accessible="isAccessible"
+          :open="internalOpen"
+        />
       </v-card-text>
       <v-card-actions>
         <v-spacer />
@@ -135,7 +142,7 @@ watch(() => props.deviceId, () => {
 
 <style scoped>
 .status-dialog {
-  max-width: 560px;
+  max-width: 900px;
 }
 .status-card {
   border: 2px solid var(--primary-color-dark);
@@ -145,6 +152,7 @@ watch(() => props.deviceId, () => {
   display: grid;
   grid-template-columns: 180px 1fr;
   gap: 8px 16px;
+  margin-bottom: 1.5rem;
 }
 .label {
   color: var(--button-secondary-bg);

--- a/src/components/Services_List.vue
+++ b/src/components/Services_List.vue
@@ -1,0 +1,396 @@
+// Copyright (c) 2025 sw.consulting
+// This file is a part of Media Pi backend
+
+<script setup>
+import { computed, ref, watch } from 'vue'
+import { storeToRefs } from 'pinia'
+
+import ActionButton from '@/components/ActionButton.vue'
+import { useDevicesStore } from '@/stores/devices.store.js'
+
+const props = defineProps({
+  deviceId: { type: Number, required: true },
+  accessible: { type: Boolean, default: false },
+  open: { type: Boolean, default: false }
+})
+
+const devicesStore = useDevicesStore()
+const { services, loading, error } = storeToRefs(devicesStore)
+
+const sortBy = ref([{ key: 'unit', order: 'asc' }])
+const lastActionMessage = ref('')
+const lastActionState = ref('success')
+const lastError = ref('')
+
+const headers = [
+  { title: '', align: 'center', key: 'actions', sortable: false, width: '5%' },
+  { title: 'Служба', align: 'start', key: 'unit' },
+  { title: 'Активность', align: 'start', key: 'active' },
+  { title: 'Состояние', align: 'start', key: 'sub' },
+  { title: 'Ошибка', align: 'start', key: 'error' }
+]
+
+const isAccessible = computed(() => Boolean(props.accessible))
+const isOpen = computed(() => Boolean(props.open))
+const isBusy = computed(() => Boolean(loading.value))
+
+const shouldLoad = computed(() => Boolean(props.deviceId) && isAccessible.value && isOpen.value)
+
+const displayServices = computed(() => {
+  if (!isAccessible.value) {
+    return []
+  }
+
+  const units = Array.isArray(services.value) ? services.value : []
+  return units.map((service, index) => {
+    const unitName = typeof service?.unit === 'string' ? service.unit : ''
+    return {
+      key: unitName || `service-${index}`,
+      unit: unitName || '—',
+      active: formatState(service?.active),
+      sub: formatState(service?.sub),
+      error: formatServiceError(service?.error)
+    }
+  })
+})
+
+const requestError = computed(() => {
+  const message = lastError.value || extractMessage(error.value)
+  return message && message.trim() ? message : ''
+})
+
+watch(shouldLoad, (value) => {
+  if (value) {
+    fetchServices()
+  }
+}, { immediate: true })
+
+watch(() => props.deviceId, () => {
+  lastActionMessage.value = ''
+  lastError.value = ''
+})
+
+watch(isOpen, (value) => {
+  if (!value) {
+    lastActionMessage.value = ''
+    lastError.value = ''
+  }
+})
+
+watch(isAccessible, (value) => {
+  if (!value) {
+    lastActionMessage.value = ''
+    lastError.value = ''
+  }
+})
+
+async function fetchServices() {
+  if (!shouldLoad.value) {
+    return
+  }
+
+  lastError.value = ''
+  try {
+    await devicesStore.listServices(props.deviceId)
+  } catch (err) {
+    lastError.value = extractMessage(err)
+  }
+}
+
+function formatState(value) {
+  if (value === null || value === undefined) {
+    return '—'
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    return trimmed.length > 0 ? trimmed : '—'
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value)
+  }
+
+  if (Array.isArray(value)) {
+    const formatted = value
+      .map(item => formatState(item))
+      .filter(item => item !== '—')
+    return formatted.length ? formatted.join(', ') : '—'
+  }
+
+  if (typeof value === 'object') {
+    if (Object.prototype.hasOwnProperty.call(value, 'Value')) {
+      return formatState(value.Value)
+    }
+    if (Object.prototype.hasOwnProperty.call(value, 'value')) {
+      return formatState(value.value)
+    }
+    if (Object.prototype.hasOwnProperty.call(value, 'State')) {
+      return formatState(value.State)
+    }
+    if (Object.prototype.hasOwnProperty.call(value, 'state')) {
+      return formatState(value.state)
+    }
+
+    for (const key of Object.keys(value)) {
+      const formatted = formatState(value[key])
+      if (formatted !== '—') {
+        return formatted
+      }
+    }
+
+    try {
+      return JSON.stringify(value)
+    } catch {
+      return String(value)
+    }
+  }
+
+  return String(value)
+}
+
+function extractMessage(err) {
+  if (!err) {
+    return ''
+  }
+
+  if (typeof err === 'string') {
+    return err
+  }
+
+  if (typeof err === 'number' || typeof err === 'boolean') {
+    return String(err)
+  }
+
+  if (typeof err === 'object') {
+    if (Object.prototype.hasOwnProperty.call(err, 'message') && typeof err.message === 'string') {
+      return err.message
+    }
+    if (Object.prototype.hasOwnProperty.call(err, 'error') && typeof err.error === 'string') {
+      return err.error
+    }
+
+    try {
+      return JSON.stringify(err)
+    } catch {
+      return String(err)
+    }
+  }
+
+  return String(err)
+}
+
+function formatServiceError(err) {
+  const message = extractMessage(err)
+  return message ? message : '—'
+}
+
+async function handleAction(actionFn, item) {
+  if (!isAccessible.value || !item || !item.unit) {
+    return
+  }
+
+  try {
+    const response = await actionFn(props.deviceId, item.unit)
+    const { message, state } = normalizeActionResponse(response)
+    lastActionMessage.value = message
+    lastActionState.value = state
+
+    if (state === 'success') {
+      await fetchServices()
+    }
+  } catch (err) {
+    lastActionMessage.value = extractMessage(err) || 'Не удалось выполнить действие'
+    lastActionState.value = 'error'
+  }
+}
+
+function normalizeActionResponse(response) {
+  if (!response) {
+    return { message: 'Операция выполнена', state: 'success' }
+  }
+
+  if (typeof response === 'string') {
+    return { message: response, state: 'success' }
+  }
+
+  if (typeof response === 'object') {
+    if (Object.prototype.hasOwnProperty.call(response, 'error') && response.error) {
+      return { message: extractMessage(response.error), state: 'error' }
+    }
+
+    if (Object.prototype.hasOwnProperty.call(response, 'result') && response.result) {
+      return { message: response.result, state: 'success' }
+    }
+
+    if (Object.prototype.hasOwnProperty.call(response, 'enabled') && typeof response.enabled === 'boolean') {
+      return {
+        message: response.enabled ? 'Служба включена' : 'Служба отключена',
+        state: 'success'
+      }
+    }
+
+    if (Object.prototype.hasOwnProperty.call(response, 'ok') && response.ok === false) {
+      return { message: 'Операция не выполнена', state: 'error' }
+    }
+  }
+
+  return { message: 'Операция выполнена', state: 'success' }
+}
+
+const startService = (item) => handleAction(devicesStore.startService, item)
+const stopService = (item) => handleAction(devicesStore.stopService, item)
+const restartService = (item) => handleAction(devicesStore.restartService, item)
+const enableService = (item) => handleAction(devicesStore.enableService, item)
+const disableService = (item) => handleAction(devicesStore.disableService, item)
+</script>
+
+<template>
+  <div class="services-list">
+    <h2 class="services-heading">Службы устройства</h2>
+    <div v-if="!isAccessible" class="services-unavailable">
+      Список служб доступен только когда устройство находится онлайн.
+    </div>
+    <template v-else>
+      <v-card class="services-card">
+        <v-data-table
+          v-if="displayServices.length"
+          :headers="headers"
+          :items="displayServices"
+          class="elevation-1"
+          item-key="key"
+          :items-per-page="-1"
+          hide-default-footer
+          v-model:sort-by="sortBy"
+        >
+          <template #item.actions="{ item }">
+            <div class="actions-container services-actions">
+              <ActionButton
+                class="start-service"
+                :item="item"
+                icon="fa-solid fa-play"
+                tooltip-text="Start"
+                :disabled="isBusy"
+                @click="startService"
+              />
+              <ActionButton
+                class="stop-service"
+                :item="item"
+                icon="fa-solid fa-hand"
+                tooltip-text="Stop"
+                :disabled="isBusy"
+                @click="stopService"
+              />
+              <ActionButton
+                class="restart-service"
+                :item="item"
+                icon="fa-solid fa-rotate-right"
+                tooltip-text="Restart"
+                :disabled="isBusy"
+                @click="restartService"
+              />
+              <ActionButton
+                class="enable-service"
+                :item="item"
+                icon="fa-solid fa-circle-check"
+                tooltip-text="Enable"
+                :disabled="isBusy"
+                @click="enableService"
+              />
+              <ActionButton
+                class="disable-service"
+                :item="item"
+                icon="fa-solid fa-ban"
+                tooltip-text="Disable"
+                :disabled="isBusy"
+                @click="disableService"
+              />
+            </div>
+          </template>
+
+          <template #item.active="{ item }">
+            <span class="services-state">{{ item.active }}</span>
+          </template>
+
+          <template #item.sub="{ item }">
+            <span class="services-state">{{ item.sub }}</span>
+          </template>
+
+          <template #item.error="{ item }">
+            <span :class="['services-state', item.error !== '—' ? 'text-danger' : '']">{{ item.error }}</span>
+          </template>
+        </v-data-table>
+        <div v-else class="services-empty">Службы не найдены.</div>
+      </v-card>
+
+      <div v-if="isBusy" class="services-loading">
+        <span class="spinner-border spinner-border-lg align-center"></span>
+      </div>
+
+      <div v-if="requestError" class="services-message text-danger">
+        {{ requestError }}
+      </div>
+
+      <div
+        v-if="lastActionMessage"
+        class="services-message"
+        :class="lastActionState === 'error' ? 'text-danger' : 'text-success'"
+      >
+        {{ lastActionMessage }}
+      </div>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.services-list {
+  margin-top: 1.5rem;
+}
+
+.services-heading {
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: var(--button-secondary-bg);
+  margin-bottom: 0.75rem;
+}
+
+.services-unavailable {
+  padding: 1rem;
+  text-align: center;
+  color: #6b7280;
+  background-color: #f3f4f6;
+  border-radius: 8px;
+}
+
+.services-card {
+  border: 1px solid var(--primary-color, #2563eb);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.services-actions {
+  justify-content: center;
+}
+
+.services-state {
+  display: inline-block;
+  min-width: 3rem;
+}
+
+.services-empty {
+  padding: 1.5rem;
+  text-align: center;
+  color: #6b7280;
+}
+
+.services-loading {
+  text-align: center;
+  margin-top: 1rem;
+}
+
+.services-message {
+  margin-top: 0.75rem;
+  text-align: center;
+  font-weight: 500;
+}
+</style>

--- a/tests/Device_Status_Dialog.spec.js
+++ b/tests/Device_Status_Dialog.spec.js
@@ -1,0 +1,126 @@
+/* @vitest-environment jsdom */
+// Copyright (c) 2025 sw.consulting
+// This file is a part of Media Pi backend
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { ref } from 'vue'
+
+import DeviceStatusDialog from '@/components/Device_Status_Dialog.vue'
+
+const statusesRef = ref([])
+const loadingRef = ref(false)
+
+const getById = vi.hoisted(() => vi.fn(() => Promise.resolve(null)))
+const getDeviceById = vi.hoisted(() => vi.fn())
+
+let deviceData
+
+vi.mock('pinia', async () => {
+  const actual = await vi.importActual('pinia')
+  return {
+    ...actual,
+    storeToRefs: (store) => store.__mockRefs
+  }
+})
+
+vi.mock('@/stores/devices.store.js', () => ({
+  useDevicesStore: () => ({
+    getDeviceById
+  })
+}))
+
+vi.mock('@/stores/device.statuses.store.js', () => ({
+  useDeviceStatusesStore: () => ({
+    __mockRefs: {
+      statuses: statusesRef,
+      loading: loadingRef
+    },
+    getById
+  })
+}))
+
+vi.mock('@/components/Services_List.vue', () => ({
+  default: {
+    name: 'ServicesList',
+    props: {
+      deviceId: { type: Number, required: true },
+      accessible: { type: Boolean, default: false },
+      open: { type: Boolean, default: false }
+    },
+    template: '<div class="services-stub" :data-device="deviceId" :data-accessible="accessible" :data-open="open"></div>'
+  }
+}))
+
+const globalStubs = {
+  'v-dialog': {
+    props: ['modelValue'],
+    emits: ['update:modelValue'],
+    template: '<div class="v-dialog"><slot /></div>'
+  },
+  'v-card': { template: '<div class="v-card"><slot /></div>' },
+  'v-card-title': { template: '<div class="v-card-title"><slot /></div>' },
+  'v-card-text': { template: '<div class="v-card-text"><slot /></div>' },
+  'v-card-actions': { template: '<div class="v-card-actions"><slot /></div>' },
+  'v-spacer': { template: '<div class="v-spacer"></div>' },
+  'font-awesome-icon': true
+}
+
+describe('Device_Status_Dialog.vue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    statusesRef.value = []
+    loadingRef.value = false
+    deviceData = {
+      id: 1,
+      name: 'Test device',
+      ipAddress: '127.0.0.1',
+      deviceStatus: {
+        deviceId: 1,
+        isOnline: false,
+        lastChecked: '2025-01-01T00:00:00Z',
+        connectLatencyMs: 0,
+        totalLatencyMs: 0
+      }
+    }
+    getDeviceById.mockImplementation((id) => (id === 1 ? deviceData : null))
+    getById.mockResolvedValue(deviceData.deviceStatus)
+  })
+
+  it('passes online accessibility to services list when status is online', () => {
+    statusesRef.value = [
+      {
+        deviceId: 1,
+        isOnline: true,
+        lastChecked: '2025-01-02T00:00:00Z',
+        connectLatencyMs: 5,
+        totalLatencyMs: 12
+      }
+    ]
+
+    const wrapper = mount(DeviceStatusDialog, {
+      props: { modelValue: true, deviceId: 1 },
+      global: { stubs: globalStubs }
+    })
+
+    const services = wrapper.findComponent({ name: 'ServicesList' })
+    expect(services.exists()).toBe(true)
+    expect(services.props('deviceId')).toBe(1)
+    expect(services.props('accessible')).toBe(true)
+    expect(services.props('open')).toBe(true)
+  })
+
+  it('passes offline accessibility to services list when device is offline', () => {
+    deviceData.deviceStatus.isOnline = false
+    statusesRef.value = []
+
+    const wrapper = mount(DeviceStatusDialog, {
+      props: { modelValue: true, deviceId: 1 },
+      global: { stubs: globalStubs }
+    })
+
+    const services = wrapper.findComponent({ name: 'ServicesList' })
+    expect(services.exists()).toBe(true)
+    expect(services.props('accessible')).toBe(false)
+  })
+})

--- a/tests/Services_List.spec.js
+++ b/tests/Services_List.spec.js
@@ -1,0 +1,187 @@
+/* @vitest-environment jsdom */
+// Copyright (c) 2025 sw.consulting
+// This file is a part of Media Pi backend
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { ref } from 'vue'
+
+import ServicesList from '@/components/Services_List.vue'
+
+const servicesRef = ref([])
+const loadingRef = ref(false)
+const errorRef = ref(null)
+
+const listServices = vi.hoisted(() => vi.fn(() => Promise.resolve()))
+const startService = vi.hoisted(() => vi.fn(() => Promise.resolve({ ok: true, result: 'started' })))
+const stopService = vi.hoisted(() => vi.fn(() => Promise.resolve({ ok: true, result: 'stopped' })))
+const restartService = vi.hoisted(() => vi.fn(() => Promise.resolve({ ok: true, result: 'restarted' })))
+const enableService = vi.hoisted(() => vi.fn(() => Promise.resolve({ ok: true, enabled: true })))
+const disableService = vi.hoisted(() => vi.fn(() => Promise.resolve({ ok: true, enabled: false })))
+
+vi.mock('pinia', async () => {
+  const actual = await vi.importActual('pinia')
+  return {
+    ...actual,
+    storeToRefs: () => ({
+      services: servicesRef,
+      loading: loadingRef,
+      error: errorRef
+    })
+  }
+})
+
+vi.mock('@/stores/devices.store.js', () => ({
+  useDevicesStore: () => ({
+    listServices,
+    startService,
+    stopService,
+    restartService,
+    enableService,
+    disableService
+  })
+}))
+
+const globalStubs = {
+  'v-card': { template: '<div class="v-card"><slot /></div>' },
+  'v-data-table': {
+    props: ['items', 'headers', 'itemKey', 'sortBy', 'itemsPerPage', 'hideDefaultFooter'],
+    template: `
+      <div class="data-table">
+        <div v-for="item in items" :key="item.key" class="service-row">
+          <slot name="item.actions" :item="item"></slot>
+          <div class="unit">{{ item.unit }}</div>
+          <div class="active">{{ item.active }}</div>
+          <div class="sub">{{ item.sub }}</div>
+          <div class="error">{{ item.error }}</div>
+        </div>
+      </div>
+    `
+  },
+  'v-tooltip': {
+    template: '<div><slot name="activator" :props="{}"></slot><slot /></div>'
+  },
+  'font-awesome-icon': true
+}
+
+describe('Services_List.vue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    servicesRef.value = []
+    loadingRef.value = false
+    errorRef.value = null
+    listServices.mockResolvedValue(undefined)
+    startService.mockResolvedValue({ ok: true, result: 'started' })
+    stopService.mockResolvedValue({ ok: true, result: 'stopped' })
+    restartService.mockResolvedValue({ ok: true, result: 'restarted' })
+    enableService.mockResolvedValue({ ok: true, enabled: true })
+    disableService.mockResolvedValue({ ok: true, enabled: false })
+  })
+
+  it('fetches services when device is accessible and dialog is open', async () => {
+    mount(ServicesList, {
+      props: { deviceId: 5, accessible: true, open: true },
+      global: { stubs: globalStubs }
+    })
+
+    await flushPromises()
+
+    expect(listServices).toHaveBeenCalledWith(5)
+  })
+
+  it('does not fetch services when device is inaccessible', async () => {
+    mount(ServicesList, {
+      props: { deviceId: 5, accessible: false, open: true },
+      global: { stubs: globalStubs }
+    })
+
+    await flushPromises()
+
+    expect(listServices).not.toHaveBeenCalled()
+  })
+
+  it('renders formatted service information', async () => {
+    servicesRef.value = [
+      { unit: 'mpd.service', active: { Value: 'active' }, sub: { Value: 'running' }, error: null }
+    ]
+
+    const wrapper = mount(ServicesList, {
+      props: { deviceId: 7, accessible: true, open: true },
+      global: { stubs: globalStubs }
+    })
+
+    await flushPromises()
+
+    expect(wrapper.html()).toContain('mpd.service')
+    expect(wrapper.html()).toContain('active')
+    expect(wrapper.html()).toContain('running')
+    expect(wrapper.html()).not.toContain('Службы не найдены')
+  })
+
+  it('invokes service actions with proper arguments', async () => {
+    servicesRef.value = [
+      { unit: 'mpd.service', active: 'active', sub: 'running', error: null }
+    ]
+
+    const wrapper = mount(ServicesList, {
+      props: { deviceId: 9, accessible: true, open: true },
+      global: { stubs: globalStubs }
+    })
+
+    await flushPromises()
+    listServices.mockClear()
+
+    await wrapper.find('button.start-service').trigger('click')
+    await flushPromises()
+    expect(startService).toHaveBeenCalledWith(9, 'mpd.service')
+    expect(listServices).toHaveBeenCalledTimes(1)
+
+    listServices.mockClear()
+    await wrapper.find('button.stop-service').trigger('click')
+    await flushPromises()
+    expect(stopService).toHaveBeenCalledWith(9, 'mpd.service')
+    expect(listServices).toHaveBeenCalledTimes(1)
+
+    listServices.mockClear()
+    await wrapper.find('button.restart-service').trigger('click')
+    await flushPromises()
+    expect(restartService).toHaveBeenCalledWith(9, 'mpd.service')
+    expect(listServices).toHaveBeenCalledTimes(1)
+
+    listServices.mockClear()
+    await wrapper.find('button.enable-service').trigger('click')
+    await flushPromises()
+    expect(enableService).toHaveBeenCalledWith(9, 'mpd.service')
+    expect(listServices).toHaveBeenCalledTimes(1)
+
+    listServices.mockClear()
+    await wrapper.find('button.disable-service').trigger('click')
+    await flushPromises()
+    expect(disableService).toHaveBeenCalledWith(9, 'mpd.service')
+    expect(listServices).toHaveBeenCalledTimes(1)
+  })
+
+  it('fetches services when accessibility changes to true', async () => {
+    const wrapper = mount(ServicesList, {
+      props: { deviceId: 11, accessible: false, open: true },
+      global: { stubs: globalStubs }
+    })
+
+    await flushPromises()
+    expect(listServices).not.toHaveBeenCalled()
+
+    await wrapper.setProps({ accessible: true })
+    await flushPromises()
+
+    expect(listServices).toHaveBeenCalledWith(11)
+  })
+
+  it('shows offline message when device is not accessible', async () => {
+    const wrapper = mount(ServicesList, {
+      props: { deviceId: 13, accessible: false, open: true },
+      global: { stubs: globalStubs }
+    })
+
+    expect(wrapper.text()).toContain('Список служб доступен только когда устройство находится онлайн')
+  })
+})


### PR DESCRIPTION
## Summary
- add a Services_List component that loads services for a device and provides start/stop/restart/enable/disable controls
- integrate the services table into Device_Status_Dialog when the device is online and widen the dialog for the new content
- cover the new component and integration with unit tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdbe05e8c08321853f0178216e51b5