### PR TITLE
Align videos store with backend API

### DIFF
--- a/src/stores/videos.store.js
+++ b/src/stores/videos.store.js
@@ -90,7 +90,7 @@ export const useVideosStore = defineStore('videos', () => {
   async function uploadFile(id, file, metadata = {}) {
     return handleRequest(
       async () => {
-        const formData = new FormData()
+        const formData = new globalThis.FormData()
         if (file !== undefined && file !== null) {
           formData.append('file', file)
         }

--- a/tests/videos.store.spec.js
+++ b/tests/videos.store.spec.js
@@ -15,6 +15,8 @@ vi.mock('@/helpers/fetch.wrapper.js', () => ({
   }
 }))
 
+/* global Blob */
+
 const mockVideos = [
   { id: 1, name: 'Video A' },
   { id: 2, name: 'Video B' }


### PR DESCRIPTION
## Summary
- remove unsupported create and file download/remove helpers from the videos store
- add support for loading videos scoped to an account and update tests accordingly

## Testing
- npm run test -- videos.store.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68e98696d89483219e345dade3ac8cb3