### PR TITLE
feat: support ordered FieldArrayWithButtons

### DIFF
--- a/src/components/FieldArrayWithButtons.vue
+++ b/src/components/FieldArrayWithButtons.vue
@@ -35,6 +35,14 @@ defineProps({
     type: String,
     default: 'Удалить элемент'
   },
+  moveUpTooltip: {
+    type: String,
+    default: 'Переместить вверх'
+  },
+  moveDownTooltip: {
+    type: String,
+    default: 'Переместить вниз'
+  },
   defaultValue: {
     type: [String, Number],
     default: ''
@@ -46,16 +54,20 @@ defineProps({
   hasError: {
     type: Boolean,
     default: false
+  },
+  ordered: {
+    type: Boolean,
+    default: false
   }
 })
 </script>
 
 <template>
-  <FieldArray :name="name" v-slot="{ fields, push, remove }">
+  <FieldArray :name="name" v-slot="{ fields, push, remove, move }">
     <div v-for="(field, idx) in fields" :key="field.key" class="form-group mb-2">
       <label v-if="idx === 0" class="label">{{ label }}:</label>
       <div v-else class="label"></div>
-      
+
       <div class="field-container">
         <!-- Plus button positioned to the left for first option -->
         <ActionButton 
@@ -78,7 +90,27 @@ defineProps({
             </option>
           </template>
         </Field>
-        
+
+        <template v-if="ordered">
+          <ActionButton
+            icon="fa-solid fa-chevron-up"
+            :item="idx"
+            @click="move(idx, idx - 1)"
+            :disabled="idx === 0"
+            class="button-o-c field-container-move field-container-move-up"
+            :tooltip-text="moveUpTooltip"
+          />
+
+          <ActionButton
+            icon="fa-solid fa-chevron-down"
+            :item="idx"
+            @click="move(idx, idx + 1)"
+            :disabled="idx === fields.length - 1"
+            class="button-o-c field-container-move field-container-move-down"
+            :tooltip-text="moveDownTooltip"
+          />
+        </template>
+
         <!-- Minus button always after select -->
         <ActionButton
           icon="fa-solid fa-minus"
@@ -151,6 +183,12 @@ defineProps({
 }
 
 .button-o-c.field-container-plus:focus {
+  outline: none;
+  border: none;
+  box-shadow: none;
+}
+
+.button-o-c.field-container-move:focus {
   outline: none;
   border: none;
   box-shadow: none;

--- a/src/components/Playlists_Settings.vue
+++ b/src/components/Playlists_Settings.vue
@@ -226,6 +226,7 @@ const cancel = () => {
           :options="videoOptions"
           placeholder="Выберите видеофайл"
           :has-error="!!errors.videoIds"
+          ordered
         />
         <div v-if="errors.videoIds" class="alert alert-danger mt-2 mb-0">{{ errors.videoIds }}</div>
       </div>

--- a/tests/FieldArrayWithButtons.spec.js
+++ b/tests/FieldArrayWithButtons.spec.js
@@ -180,18 +180,67 @@ describe('FieldArrayWithButtons', () => {
 
   it('renders custom tooltips', async () => {
     const wrapper = createWrapper({
+      ordered: true,
       addTooltip: 'Custom Add',
-      removeTooltip: 'Custom Remove'
-    })
+      removeTooltip: 'Custom Remove',
+      moveUpTooltip: 'Move Up',
+      moveDownTooltip: 'Move Down'
+    }, { testField: ['', ''] })
     await flushPromises()
-    
+
     // Check ActionButton components directly
     const actionButtons = wrapper.findAllComponents({ name: 'ActionButton' })
     const plusButton = actionButtons.find(btn => btn.classes().includes('field-container-plus'))
     const minusButton = actionButtons.find(btn => btn.classes().includes('ml-2'))
-    
+    const moveUpButton = actionButtons.find(btn => btn.classes().includes('field-container-move-up') && !btn.attributes('disabled'))
+    const moveDownButton = actionButtons.find(btn => btn.classes().includes('field-container-move-down') && !btn.attributes('disabled'))
+
     expect(plusButton.props('tooltipText')).toBe('Custom Add')
     expect(minusButton.props('tooltipText')).toBe('Custom Remove')
+    expect(moveUpButton?.props('tooltipText')).toBe('Move Up')
+    expect(moveDownButton?.props('tooltipText')).toBe('Move Down')
+  })
+
+  it('renders move buttons when ordered is true', async () => {
+    const wrapper = createWrapper({ ordered: true }, { testField: ['', ''] })
+    await flushPromises()
+
+    const moveUpButtons = wrapper.findAll('button.field-container-move-up')
+    const moveDownButtons = wrapper.findAll('button.field-container-move-down')
+
+    expect(moveUpButtons).toHaveLength(2)
+    expect(moveDownButtons).toHaveLength(2)
+
+    expect(moveUpButtons[0].attributes('disabled')).toBeDefined()
+    expect(moveDownButtons[1].attributes('disabled')).toBeDefined()
+  })
+
+  it('moves items when move buttons are clicked', async () => {
+    const wrapper = createWrapper(
+      {
+        ordered: true,
+        fieldType: 'input',
+        fieldProps: { type: 'text' }
+      },
+      { testField: ['first', 'second', 'third'] }
+    )
+    await flushPromises()
+
+    const getValues = () => wrapper.findAll('input').map(input => input.element.value)
+
+    expect(getValues()).toEqual(['first', 'second', 'third'])
+
+    const firstDownButton = wrapper.findAll('button.field-container-move-down')[0]
+    await firstDownButton.trigger('click')
+    await flushPromises()
+
+    expect(getValues()).toEqual(['second', 'first', 'third'])
+
+    const secondUpButton = wrapper.findAll('button.field-container-move-up')[1]
+    await secondUpButton.trigger('click')
+    await flushPromises()
+
+    expect(getValues()).toEqual(['first', 'second', 'third'])
   })
 
   it('uses custom default value when adding fields', async () => {


### PR DESCRIPTION
## Summary
- add optional ordered mode to FieldArrayWithButtons with move controls and tooltips
- update playlist settings to enable ordered field arrays for video selection
- expand unit tests to cover ordering controls and tooltips

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f61ce983248321bd8591d8c7980b42