### PR TITLE
Add playback and upload actions to devices store

### DIFF
--- a/src/stores/devices.store.js
+++ b/src/stores/devices.store.js
@@ -267,6 +267,11 @@ export const useDevicesStore = defineStore('devices', () => {
   const reloadSystem = (id) => executeDeviceRequest('post', id, ['system', 'reload'])
   const rebootSystem = (id) => executeDeviceRequest('post', id, ['system', 'reboot'])
   const shutdownSystem = (id) => executeDeviceRequest('post', id, ['system', 'shutdown'])
+  const startPlayback = (id) => executeDeviceRequest('post', id, ['playback', 'start'])
+  const stopPlayback = (id) => executeDeviceRequest('post', id, ['playback', 'stop'])
+  const startUpload = (id) => executeDeviceRequest('post', id, ['playlist', 'start-upload'])
+  const stopUpload = (id) => executeDeviceRequest('post', id, ['playlist', 'stop-upload'])
+  const getServiceStatus = (id) => executeDeviceRequest('get', id, ['service', 'status'])
 
   return {
     devices,
@@ -298,7 +303,12 @@ export const useDevicesStore = defineStore('devices', () => {
     updateAudio,
     reloadSystem,
     rebootSystem,
-    shutdownSystem
+    shutdownSystem,
+    startPlayback,
+    stopPlayback,
+    startUpload,
+    stopUpload,
+    getServiceStatus
   }
 })
 


### PR DESCRIPTION
## Summary
- add playback, upload, and service status actions to the devices store via shared request utility
- extend devices store unit tests to cover new endpoints and error handling

## Testing
- npm test -- tests/devices.store.spec.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e356ea0448321aca0ff4f36a976c0)