### PR TITLE
Add screenshot interval setting to Device Management (state, UI, payload, tests)

### DIFF
--- a/src/components/Device_Management.vue
+++ b/src/components/Device_Management.vue
@@ -140,6 +140,11 @@ const playlistSettings = ref({
   destination: ''
 })
 
+// Screenshot settings state
+const screenshotSettings = ref({
+  intervalMinutes: 0
+})
+
 const defaultTimeValue = '00:00'
 const createDefaultRestPair = () => ({ start: defaultTimeValue, stop: defaultTimeValue })
 const createDefaultScheduleValues = () => ({
@@ -221,7 +226,8 @@ const applyScheduleValues = (values) => {
 const createDefaultConfiguration = () => ({
   playlist: { source: '', destination: '' },
   schedule: createDefaultScheduleValues(),
-  audio: { output: 'hdmi' }
+  audio: { output: 'hdmi' },
+  screenshot: { intervalMinutes: 0 }
 })
 
 const normalizeConfiguration = (config = {}) => {
@@ -230,6 +236,10 @@ const normalizeConfiguration = (config = {}) => {
     ? config.audio.output.trim().toLowerCase()
     : ''
   const audioFallback = !allowedOutputs.includes(rawAudioOutput)
+  const screenshotIntervalRaw = Number(config?.screenshot?.intervalMinutes)
+  const screenshotIntervalMinutes = Number.isInteger(screenshotIntervalRaw) && screenshotIntervalRaw >= 0
+    ? screenshotIntervalRaw
+    : 0
 
   return {
     playlist: {
@@ -243,6 +253,9 @@ const normalizeConfiguration = (config = {}) => {
     },
     audio: {
       output: audioFallback ? 'hdmi' : rawAudioOutput
+    },
+    screenshot: {
+      intervalMinutes: screenshotIntervalMinutes
     },
     audioFallback
   }
@@ -258,6 +271,7 @@ const applyConfiguration = (configuration, originalConfig = {}) => {
     alertStore.error('Неизвестный тип аудио выхода. Установлено значение по умолчанию: HDMI')
   }
   audioSettings.value.output = normalized.audio.output
+  screenshotSettings.value.intervalMinutes = normalized.screenshot.intervalMinutes
 }
 
 const buildSchedulePayload = (values) => ({
@@ -274,6 +288,11 @@ const buildConfigurationPayload = (scheduleValuesOverride) => ({
   schedule: buildSchedulePayload(scheduleValuesOverride ?? scheduleFormValues.value),
   audio: {
     output: ['hdmi', 'jack'].includes(audioSettings.value.output) ? audioSettings.value.output : 'hdmi'
+  },
+  screenshot: {
+    intervalMinutes: Number.isInteger(Number(screenshotSettings.value.intervalMinutes))
+      ? Math.max(0, Number(screenshotSettings.value.intervalMinutes))
+      : 0
   }
 })
 
@@ -353,6 +372,7 @@ async function initializeDevice() {
     resetServiceStatus()
     // Set default audio value silently when device is offline
     audioSettings.value.output = 'hdmi'
+    screenshotSettings.value.intervalMinutes = 0
     playlistSettings.value.source = ''
     playlistSettings.value.destination = ''
     applyScheduleValues(createDefaultScheduleValues())
@@ -851,7 +871,7 @@ onBeforeUnmount(() => {
             type="text"
             class="form-control input"
             :disabled="isDisabled || hasAnyOperationInProgress"
-            placeholder="Путь к локальному диске"
+            placeholder="Каталог на устройстве"
           />
         </div>
         <div class="playlist-cell label playlist-label">Аудиовыход</div>
@@ -865,6 +885,18 @@ onBeforeUnmount(() => {
             <option value="hdmi">HDMI audio</option>
             <option value="jack">3.5" jack audio</option>
           </select>
+        </div>
+        <div class="playlist-cell label playlist-label">Частота снимков (мин)</div>
+        <div class="playlist-cell">
+          <input
+            id="screenshot-interval-minutes"
+            v-model.number="screenshotSettings.intervalMinutes"
+            type="number"
+            min="0"
+            step="1"
+            class="form-control input"
+            :disabled="isDisabled || hasAnyOperationInProgress"
+          />
         </div>
       </div>
     </div>

--- a/src/components/Device_Management.vue
+++ b/src/components/Device_Management.vue
@@ -509,6 +509,9 @@ const persistConfiguration = async ({
 
   const payload = buildConfigurationPayload(scheduleValues)
 
+  // Sync normalized screenshot value back to state so UI stays in sync with what is saved
+  screenshotSettings.value.intervalMinutes = payload.screenshot.intervalMinutes
+
   try {
     await devicesStore.updateConfiguration(props.deviceId, payload)
     // always apply schedule values from saved payload so internal state reflects saved data

--- a/tests/Device_Management.spec.js
+++ b/tests/Device_Management.spec.js
@@ -66,7 +66,8 @@ const configurationResponse = {
     video: ['00:00'],
     rest: [{ start: '00:00', stop: '00:00' }]
   },
-  audio: { output: 'hdmi' }
+  audio: { output: 'hdmi' },
+  screenshot: { intervalMinutes: 15 }
 }
 const getConfiguration = vi.fn(() => Promise.resolve(configurationResponse))
 const updateConfiguration = vi.fn(() => Promise.resolve())
@@ -277,8 +278,71 @@ describe('Device_Management.vue', () => {
     await flushPromises()
 
     expect(updateConfiguration).toHaveBeenCalledTimes(1)
-    expect(updateConfiguration).toHaveBeenCalledWith(1, expect.objectContaining({ audio: { output: 'hdmi' } }))
+    expect(updateConfiguration).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({
+        audio: { output: 'hdmi' },
+        screenshot: { intervalMinutes: 15 }
+      })
+    )
     expect(alertSuccess).toHaveBeenCalledWith('Все настройки сохранены')
+  })
+
+  it('renders screenshot interval field in other settings', async () => {
+    const wrapper = mount(DeviceManagement, {
+      props: { deviceId: 1 },
+      global: {
+        stubs: {
+          'font-awesome-icon': { template: '<i />' }
+        }
+      }
+    })
+
+    await flushPromises()
+
+    const labels = wrapper.findAll('.playlist-grid .playlist-label').map((label) => label.text())
+    const screenshotInput = wrapper.find('#screenshot-interval-minutes')
+
+    expect(labels).toContain('Частота снимков (мин)')
+    expect(screenshotInput.exists()).toBe(true)
+    expect(screenshotInput.element.value).toBe('15')
+  })
+
+  it('normalizes invalid screenshot interval to 0 before save', async () => {
+    vi.useRealTimers()
+    getConfiguration.mockResolvedValueOnce({
+      ...configurationResponse,
+      screenshot: { intervalMinutes: -5 }
+    })
+
+    const wrapper = mount(DeviceManagement, {
+      props: { deviceId: 1 },
+      global: {
+        stubs: {
+          'font-awesome-icon': { template: '<i />' }
+        }
+      }
+    })
+
+    await flushPromises()
+
+    wrapper.vm.scheduleFormRef.value = {
+      validate: vi.fn().mockResolvedValue({ valid: true }),
+      values: configurationResponse.schedule
+    }
+
+    await wrapper.vm.persistConfiguration({
+      errorPrefix: 'Не удалось сохранить настройки',
+      successMessage: 'Все настройки сохранены'
+    })
+    await flushPromises()
+
+    expect(updateConfiguration).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({
+        screenshot: { intervalMinutes: 0 }
+      })
+    )
   })
 
   it('handles configuration load error on readAll', async () => {

--- a/tests/Device_Management.spec.js
+++ b/tests/Device_Management.spec.js
@@ -310,10 +310,6 @@ describe('Device_Management.vue', () => {
 
   it('normalizes invalid screenshot interval to 0 before save', async () => {
     vi.useRealTimers()
-    getConfiguration.mockResolvedValueOnce({
-      ...configurationResponse,
-      screenshot: { intervalMinutes: -5 }
-    })
 
     const wrapper = mount(DeviceManagement, {
       props: { deviceId: 1 },
@@ -325,6 +321,10 @@ describe('Device_Management.vue', () => {
     })
 
     await flushPromises()
+
+    // Simulate user entering an invalid (negative) value into the field after mount
+    const screenshotInput = wrapper.find('#screenshot-interval-minutes')
+    await screenshotInput.setValue(-5)
 
     wrapper.vm.scheduleFormRef.value = {
       validate: vi.fn().mockResolvedValue({ valid: true }),
@@ -343,6 +343,9 @@ describe('Device_Management.vue', () => {
         screenshot: { intervalMinutes: 0 }
       })
     )
+
+    // Verify UI is also normalized to 0 after save (not left displaying the invalid value)
+    expect(Number(wrapper.find('#screenshot-interval-minutes').element.value)).toBe(0)
   })
 
   it('handles configuration load error on readAll', async () => {


### PR DESCRIPTION
### Motivation
- Expose a configurable screenshot capture frequency for devices so users can set how often screenshots are taken. 
- Persist the new setting through the existing device configuration flow and ensure invalid values are normalized before sending to the backend.

### Description
- Added `screenshotSettings` reactive state and included `screenshot.intervalMinutes` in the default configuration returned by `createDefaultConfiguration`.
- Extended `normalizeConfiguration`, `applyConfiguration`, and `buildConfigurationPayload` to handle `screenshot.intervalMinutes` and to normalize invalid values to `0`.
- Added an input field with id `screenshot-interval-minutes` in the "Другие настройки" section and updated the playlist destination placeholder to `Каталог на устройстве`.
- Updated unit tests in `tests/Device_Management.spec.js` to include `screenshot` in the mocked configuration, to expect the screenshot field in the saved payload, and added tests that verify the UI renders the field and that negative intervals are normalized to `0` before save.

### Testing
- Ran the component unit tests with `vitest` in `tests/Device_Management.spec.js`, including `saves all settings using combined endpoint`, `renders screenshot interval field in other settings`, and `normalizes invalid screenshot interval to 0 before save`.
- All modified and added tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69deb4e21d2c8321885063ae1cea6a74)