### PR TITLE
fix: add workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: '${{ github.workflow }}-${{ github.job }}-${{ github.head_ref || github.ref_name }}'
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/sw-consulting/media-pi.ui/security/code-scanning/1](https://github.com/sw-consulting/media-pi.ui/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/ci.yml` at the workflow root (recommended here since there is only one job).  
Use the minimal required scope:

- `contents: read`

This does not change existing functionality for the shown steps (checkout/test/build/codecov upload via `CODECOV_TOKEN`) and documents intended token access clearly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
